### PR TITLE
[feat] vote case별로 상태값 변경하고 count 업데이트

### DIFF
--- a/src/main/java/clov3r/oneit_server/domain/collection/GiftboxProductVoteId.java
+++ b/src/main/java/clov3r/oneit_server/domain/collection/GiftboxProductVoteId.java
@@ -22,6 +22,9 @@ public class GiftboxProductVoteId implements Serializable {
   @Column(name = "product_idx")
   private Long productIdx;
 
+  @Column(name = "user_idx")
+  private Long userIdx;
+
   @Column(name = "browser_uuid")
   private String browserUuid;
 }

--- a/src/main/java/clov3r/oneit_server/domain/entity/GiftboxProduct.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/GiftboxProduct.java
@@ -41,6 +41,9 @@ public class GiftboxProduct extends BaseEntity {
     @Column(name = "like_count")
     private int likeCount;
 
+    @Column(name = "dislike_count")
+    private int dislikeCount;
+
 
     public GiftboxProduct(Giftbox giftbox, Product product, Status status) {
         this.giftbox = giftbox;

--- a/src/main/java/clov3r/oneit_server/domain/entity/GiftboxProductVote.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/GiftboxProductVote.java
@@ -9,7 +9,6 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -27,13 +26,8 @@ public class GiftboxProductVote {
   @EmbeddedId
   private GiftboxProductVoteId id;
 
-  @ManyToOne(fetch = LAZY)
-  @JoinColumn(name = "user_idx")
-  private User user;
-
   @Enumerated(EnumType.STRING)
   @Column(name = "vote")
   private VoteStatus vote;
-
 
 }

--- a/src/main/java/clov3r/oneit_server/domain/entity/Product.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/Product.java
@@ -40,8 +40,8 @@ public class Product extends BaseEntity {
     @Column(name = "brand_name")
     private String brandName;
 
-    @Column(name = "brand_description")
-    private String brandDescription;
+    @Column(name = "description")
+    private String description;
 
     @Column(name = "product_url")
     private String productUrl;
@@ -66,23 +66,4 @@ public class Product extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
-    @Override
-    public String toString() {
-        return "Product{" +
-                "idx=" + idx +
-                ", name='" + name + '\'' +
-                ", originalPrice=" + originalPrice +
-                ", currentPrice=" + currentPrice +
-                ", discountRate=" + discountRate +
-                ", mallName='" + mallName + '\'' +
-                ", brandName='" + brandName + '\'' +
-                ", brandDescription='" + brandDescription + '\'' +
-                ", productUrl='" + productUrl + '\'' +
-                ", thumbnailUrl='" + thumbnailUrl + '\'' +
-                ", gender=" + gender +
-                ", category=" + category +
-                ", categoryDisplayName='" + categoryDisplayName + '\'' +
-                ", productKeywords=" + productKeywords +
-                '}';
-    }
 }

--- a/src/main/java/clov3r/oneit_server/repository/GiftboxProductCustomRepository.java
+++ b/src/main/java/clov3r/oneit_server/repository/GiftboxProductCustomRepository.java
@@ -7,10 +7,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GiftboxProductCustomRepository {
 
-  void voteProduct(GiftboxProductVote giftboxProductVote);
-
-  void countLike(Long giftboxIdx, Long productIdx);
+  VoteStatus voteProduct(GiftboxProductVote giftboxProductVote);
 
   VoteStatus getVoteStatusOfUser(Long userIdx, Long giftboxIdx, Long idx);
 
+  void updateLikeCount(Long giftboxIdx, Long productIdx, int i);
+
+  void updateDislikeCount(Long giftboxIdx, Long productIdx, int i);
 }

--- a/src/main/java/clov3r/oneit_server/service/GiftboxProductService.java
+++ b/src/main/java/clov3r/oneit_server/service/GiftboxProductService.java
@@ -12,32 +12,69 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class GiftboxProductService {
-    private final GiftboxProductRepository giftboxProductRepository;
 
-    @Transactional
-    public void voteProduct(GiftboxProductVote giftboxProductVote) {
-      try {
-        giftboxProductRepository.voteProduct(giftboxProductVote);
+  private final GiftboxProductRepository giftboxProductRepository;
 
-      } catch (BaseException e) {
-        System.out.println("GiftboxProductService.voteProduct");
-        System.out.println("e = " + e);
-        throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+  public VoteStatus voteProduct(GiftboxProductVote giftboxProductVote) {
+    try {
+      VoteStatus previousStatus = giftboxProductRepository.voteProduct(giftboxProductVote);
+      return previousStatus;
+    } catch (BaseException e) {
+      throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+    }
+  }
+
+  public void updateVoteCount(Long giftboxIdx, Long productIdx, VoteStatus previousVote, VoteStatus newVote) {
+
+
+    try {
+      // 이전 상태가 없는 경우
+      if (previousVote == null) {
+
+        if (newVote.equals(VoteStatus.LIKE)) {
+          // like +1
+          giftboxProductRepository.updateLikeCount(giftboxIdx, productIdx, 1);
+        } else if (newVote.equals(VoteStatus.DISLIKE)) {
+          // dislike +1
+          giftboxProductRepository.updateDislikeCount(giftboxIdx, productIdx, 1);
+        }
+      } else {
+
+        // 상태가 바뀔 경우에만 업데이트
+        // 이전 상태가 LIKE or DISLIKE 인 경우 -> LIKE  -1 / DISLIKE -1
+        // 새로운 상태가 LIKE or DISLIKE 인 경우 -> LIKE +1 / DISLIKE +1
+        if (!previousVote.equals(newVote)) {
+          if (previousVote.equals(VoteStatus.LIKE)) {
+            // like -1
+            giftboxProductRepository.updateLikeCount(giftboxIdx, productIdx, -1);
+          } else if (previousVote.equals(VoteStatus.DISLIKE)) {
+            // dislike -1
+            giftboxProductRepository.updateDislikeCount(giftboxIdx, productIdx, -1);
+          }
+
+          if (newVote.equals(VoteStatus.LIKE)) {
+            // like +1
+            giftboxProductRepository.updateLikeCount(giftboxIdx, productIdx, 1);
+          } else if (newVote.equals(VoteStatus.DISLIKE)) {
+            // dislike +1
+            giftboxProductRepository.updateDislikeCount(giftboxIdx, productIdx, 1);
+          }
+        }
+
       }
-    }
 
-    @Transactional
-    public void countLike(Long giftboxIdx, Long productIdx) {
-      giftboxProductRepository.countLike(giftboxIdx, productIdx);
+    } catch (BaseException e) {
+      throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
     }
+  }
 
 
-    public VoteStatus getVoteStatusOfUser(Long userIdx, Long giftboxIdx, Long idx) {
-      VoteStatus voteStatus = giftboxProductRepository.getVoteStatusOfUser(userIdx, giftboxIdx, idx);
-      if (voteStatus == null) {
-        return VoteStatus.NONE;
-      }
-      return voteStatus;
+  public VoteStatus getVoteStatusOfUser(Long userIdx, Long giftboxIdx, Long idx) {
+    VoteStatus voteStatus = giftboxProductRepository.getVoteStatusOfUser(userIdx, giftboxIdx, idx);
+    if (voteStatus == null || voteStatus == VoteStatus.NONE) {
+      return VoteStatus.NONE;
     }
+    return voteStatus;
+  }
 
 }


### PR DESCRIPTION
# [ONE-527] 좋아요 기능 업데이트
## 🔑 Key Change 
- 처음 좋아요 클릭시 DB에 저장
- 두번째부터 이전 상태와 달라졌을 경우 상태값 변경하고 count update
- 같은 선물바구니, 제품, 브라우저일 때 유저가 달라져도 가능하도록 테이블의 pk에 user idx 추가
- 현재는 로그인 유저만 가능한 기능임

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 
- remark 1


[ONE-527]: https://clov3r.atlassian.net/browse/ONE-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ