### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/clov3r/oneit_server/controller/AuthControllerV2.java
+++ b/src/main/java/clov3r/oneit_server/controller/AuthControllerV2.java
@@ -5,10 +5,13 @@ import clov3r.oneit_server.config.security.TokenProvider;
 import clov3r.oneit_server.domain.DTO.KakaoFriendDTO;
 import clov3r.oneit_server.domain.DTO.KakaoLoginDTO;
 import clov3r.oneit_server.domain.DTO.KakaoProfileDTO;
+import clov3r.oneit_server.domain.DTO.FriendDTO;
+import clov3r.oneit_server.domain.DTO.UserDTO;
 import clov3r.oneit_server.domain.data.AuthToken;
 import clov3r.oneit_server.domain.data.status.UserStatus;
 import clov3r.oneit_server.domain.entity.User;
 import clov3r.oneit_server.domain.request.KakaoAccessToken;
+import clov3r.oneit_server.domain.request.SignupRequest;
 import clov3r.oneit_server.repository.AuthRepository;
 import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.service.AuthService;
@@ -35,14 +38,14 @@ public class AuthControllerV2 {
     private final TokenProvider tokenProvider;
 
 
-    @Tag(name = "카카오 로그인 API", description = "카카오 로그인 관련 API 목록")
+    @Tag(name = "계정 API", description = "회원가입/로그인 관련 API 목록")
     @Operation(summary = "카카오 로그인", description = "유저의 카카오 액세스 토큰을 입력받아 자체 서비스에서 카카오 로그인을 진행합니다.")
     @PostMapping("/api/v2/kakao/login")
     public ResponseEntity<KakaoLoginDTO> kakaoLogin(@RequestBody KakaoAccessToken kakaoAccessToken) {
         KakaoProfileDTO kakaoProfileDTO = authService.getKaKaoUserInfo(kakaoAccessToken.getAccessToken());
         User user;
-        if (userRepository.existsUserByEmail(kakaoProfileDTO.getKakao_account().getEmail())) {
-            user = userRepository.findUserByEmail(kakaoProfileDTO.getKakao_account().getEmail());
+        if (userRepository.existsByEmail(kakaoProfileDTO.getKakao_account().getEmail())) {
+            user = userRepository.findByEmail(kakaoProfileDTO.getKakao_account().getEmail());
             if (!user.getStatus().equals(UserStatus.ACTIVE)) {
                 user.setStatus(UserStatus.ACTIVE); 
             }
@@ -58,7 +61,7 @@ public class AuthControllerV2 {
     }
 
     // 헤더에서 토큰을 가져와 검증한 뒤에 유효하다면 user idx를 꺼내서 유저의 정보를 반환하는 API
-    @Tag(name = "카카오 로그인 API", description = "카카오 로그인 관련 API 목록")
+    @Tag(name = "계정 API", description = "회원가입/로그인 관련 API 목록")
     @Operation(summary = "카카오 로그인 유저 조회", description = "헤더에 담긴 토큰을 검증하여 유저의 정보를 반환합니다.")
     @GetMapping("/api/v2/kakao/user")
     public ResponseEntity<User> getUserInfo (
@@ -69,13 +72,33 @@ public class AuthControllerV2 {
     }
 
     // 유저의 카카오톡 친구 목록을 가져오는 API
-    @Tag(name = "카카오 로그인 API", description = "카카오 로그인 관련 API 목록")
+    @Tag(name = "계정 API", description = "회원가입/로그인 관련 API 목록")
     @Operation(summary = "카카오 친구 목록 조회", description = "유저의 카카오톡 친구 목록을 조회합니다.")
     @GetMapping("/api/v2/kakao/friends")
     public ResponseEntity<KakaoFriendDTO> getFriends(
         @RequestBody KakaoAccessToken kakaoAccessToken
     ) {
         return ResponseEntity.ok(authService.getKakaoFriends(kakaoAccessToken.getAccessToken()));
+    }
+
+    @Tag(name = "계정 API", description = "회원가입/로그인 관련 API 목록")
+    @Operation(summary = "ONEIT 회원가입", description = "이름, 닉네임, 성별, 생년월일을 추가로 입력받습니다.")
+    @PostMapping("/api/v2/signup")
+    public ResponseEntity<UserDTO> signUp(
+        @RequestBody SignupRequest signupRequest,
+        @Parameter(hidden = true) @Auth Long userIdx
+        ) {
+        User user = userService.signUp(signupRequest, userIdx);
+        UserDTO newUser = UserDTO.builder()
+            .idx(user.getIdx())
+            .email(user.getEmail())
+            .name(user.getName())
+            .nickname(user.getNickname())
+            .profileImg(user.getProfileImg())
+            .gender(user.getGender())
+            .birthDate(user.getBirthDate())
+            .build();
+        return ResponseEntity.ok(newUser);
     }
 
 }

--- a/src/main/java/clov3r/oneit_server/controller/FriendController.java
+++ b/src/main/java/clov3r/oneit_server/controller/FriendController.java
@@ -7,9 +7,8 @@ import static clov3r.oneit_server.error.errorcode.CustomErrorCode.INVALID_SELF_R
 import clov3r.oneit_server.config.security.Auth;
 import clov3r.oneit_server.domain.DTO.FriendReqDTO;
 import clov3r.oneit_server.domain.DTO.RequestFriendDTO;
-import clov3r.oneit_server.domain.DTO.UserDTO;
+import clov3r.oneit_server.domain.DTO.FriendDTO;
 import clov3r.oneit_server.domain.entity.FriendReq;
-import clov3r.oneit_server.domain.entity.Friendship;
 import clov3r.oneit_server.error.exception.BaseExceptionV2;
 import clov3r.oneit_server.repository.FriendReqRepository;
 import clov3r.oneit_server.service.FriendService;
@@ -134,10 +133,10 @@ public class FriendController {
   @Tag(name = "친구관리 API", description = "친구 관련 API")
   @Operation(summary = "친구 목록 확인", description = "나의 친구 목록을 확인합니다.")
   @GetMapping("/api/v2/friends")
-  public ResponseEntity<List<UserDTO>> getFriends(
+  public ResponseEntity<List<FriendDTO>> getFriends(
       @Parameter(hidden = true) @Auth Long userIdx
   ) {
-    List<UserDTO> friends = friendService.getFriends(userIdx);
+    List<FriendDTO> friends = friendService.getFriends(userIdx);
     return ResponseEntity.ok(friends);
   }
 

--- a/src/main/java/clov3r/oneit_server/controller/GiftboxControllerV2.java
+++ b/src/main/java/clov3r/oneit_server/controller/GiftboxControllerV2.java
@@ -58,7 +58,7 @@ public class GiftboxControllerV2 {
     if (request.getName() == null || request.getDeadline() == null || userIdx == null) {
       throw new BaseExceptionV2(REQUEST_ERROR);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (request.getDeadline().isBefore(LocalDateTime.now().toLocalDate())) {
@@ -110,7 +110,7 @@ public class GiftboxControllerV2 {
             participant.getUser().getIdx(),
             participant.getUser().getNickname(),
             participant.getUser().getName(),
-            participant.getUser().getProfileImgFromKakao(),
+            participant.getUser().getProfileImg(),
             participant.getUserRole()
         ))
         .toList();
@@ -136,7 +136,7 @@ public class GiftboxControllerV2 {
       @Parameter(hidden = true) @Auth Long userIdx
   ) {
     // request validation
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
 
@@ -151,7 +151,7 @@ public class GiftboxControllerV2 {
                   participant.getUser().getIdx(),
                   participant.getUser().getNickname(),
                   participant.getUser().getName(),
-                  participant.getUser().getProfileImgFromKakao(),
+                  participant.getUser().getProfileImg(),
                   participant.getUserRole()
               ))
               .toList();
@@ -181,7 +181,7 @@ public class GiftboxControllerV2 {
     if (giftboxRepository.findById(giftboxIdx) == null) {
       throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isManagerOfGiftbox(userIdx, giftboxIdx)) {
@@ -209,7 +209,7 @@ public class GiftboxControllerV2 {
     if (request.getName() == null || request.getDeadline() == null || userIdx == null) {
       throw new BaseExceptionV2(REQUEST_ERROR);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isManagerOfGiftbox(userIdx, giftboxIdx)) {
@@ -250,7 +250,7 @@ public class GiftboxControllerV2 {
     if (!giftboxRepository.existsById(giftboxIdx)) {
       throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -289,7 +289,7 @@ public class GiftboxControllerV2 {
     if (!giftboxRepository.existsById(giftboxUser.getGiftbox().getIdx())) {
       throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
 
@@ -313,7 +313,7 @@ public class GiftboxControllerV2 {
     if (!giftboxRepository.existsById(giftboxIdx)) {
       throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -326,7 +326,7 @@ public class GiftboxControllerV2 {
             participant.getUser().getIdx(),
             participant.getUser().getNickname(),
             participant.getUser().getName(),
-            participant.getUser().getProfileImgFromKakao(),
+            participant.getUser().getProfileImg(),
             participant.getUserRole()
         ))
         .toList();

--- a/src/main/java/clov3r/oneit_server/controller/GiftboxProductControllerV2.java
+++ b/src/main/java/clov3r/oneit_server/controller/GiftboxProductControllerV2.java
@@ -65,7 +65,7 @@ public class GiftboxProductControllerV2 {
         throw new BaseExceptionV2(PRODUCT_NOT_FOUND);
       }
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -142,7 +142,7 @@ public class GiftboxProductControllerV2 {
     if (giftboxRepository.findById(giftboxIdx) == null) {
       throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -197,7 +197,7 @@ public class GiftboxProductControllerV2 {
 //    }
 
     // 로그인 유저만 가능한 경우
-    if (userIdx == null || !userRepository.existsUser(userIdx)) {
+    if (userIdx == null || !userRepository.existsByUserIdx(userIdx)) {
       throw new BaseExceptionV2(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, request.getGiftboxIdx())) {

--- a/src/main/java/clov3r/oneit_server/domain/DTO/FriendDTO.java
+++ b/src/main/java/clov3r/oneit_server/domain/DTO/FriendDTO.java
@@ -1,0 +1,27 @@
+package clov3r.oneit_server.domain.DTO;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+public class FriendDTO {
+
+      private Long idx;
+      private String name;
+      private String nickName;
+      private String profileImg;
+      private LocalDate birthDate;
+
+      public FriendDTO(Long idx, String name, String nickName, String profileImg, LocalDate birthDate) {
+        this.idx = idx;
+        this.name = name;
+        this.nickName = nickName;
+        this.profileImg = profileImg;
+        this.birthDate = birthDate;
+      }
+
+}

--- a/src/main/java/clov3r/oneit_server/domain/DTO/FriendReqDTO.java
+++ b/src/main/java/clov3r/oneit_server/domain/DTO/FriendReqDTO.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 public class FriendReqDTO {
 
   private Long requestIdx;
-  private UserDTO fromUser;
+  private FriendDTO fromUser;
   private LocalDateTime requestDate;
 
-  public FriendReqDTO(Long requestIdx, UserDTO fromUser, LocalDateTime requestDate) {
+  public FriendReqDTO(Long requestIdx, FriendDTO fromUser, LocalDateTime requestDate) {
     this.requestIdx = requestIdx;
     this.fromUser = fromUser;
     this.requestDate = requestDate;

--- a/src/main/java/clov3r/oneit_server/domain/DTO/UserDTO.java
+++ b/src/main/java/clov3r/oneit_server/domain/DTO/UserDTO.java
@@ -1,27 +1,23 @@
 package clov3r.oneit_server.domain.DTO;
 
+import clov3r.oneit_server.domain.data.AuthToken;
+import clov3r.oneit_server.domain.data.Gender;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 public class UserDTO {
-
-      private Long idx;
-      private String name;
-      private String nickName;
-      private String profileImg;
-      private LocalDate birthDate;
-
-      public UserDTO(Long idx, String name, String nickName, String profileImg, LocalDate birthDate) {
-        this.idx = idx;
-        this.name = name;
-        this.nickName = nickName;
-        this.profileImg = profileImg;
-        this.birthDate = birthDate;
-      }
-
+    private Long idx;
+    private String email;
+    private String name;
+    private String nickname;
+    private String profileImg;
+    private Gender gender;
+    private LocalDate birthDate;
 }

--- a/src/main/java/clov3r/oneit_server/domain/entity/User.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/User.java
@@ -32,10 +32,15 @@ public class User extends BaseEntity {
     @Column(name = "nickname_from_kakao")
     private String nicknameFromKakao;
 
+    @Column(name = "profile_img")
+    private String profileImg;
+
     @Column(name = "profile_img_from_kakao")
     private String profileImgFromKakao;
 
-    private String gender;  //  product gender enum 과 다름
+    @Enumerated(EnumType.STRING)
+    private Gender gender;  //  product gender enum 과 다름
+
     private String age;
     private LocalDate birthDate;
 
@@ -47,8 +52,10 @@ public class User extends BaseEntity {
     public User(String email, String nickname, String profileImage, UserStatus status) {
         this.email = email;
         this.nickname = nickname;
+        this.profileImg = profileImage;
         this.profileImgFromKakao = profileImage;
         this.status = status;
         this.createBaseEntity();
     }
+
 }

--- a/src/main/java/clov3r/oneit_server/domain/request/SignupRequest.java
+++ b/src/main/java/clov3r/oneit_server/domain/request/SignupRequest.java
@@ -1,0 +1,13 @@
+package clov3r.oneit_server.domain.request;
+
+import clov3r.oneit_server.domain.data.Gender;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class SignupRequest {
+    private String name;
+    private String nickname;
+    private LocalDate birthDate;
+    private Gender gender;
+}

--- a/src/main/java/clov3r/oneit_server/error/exception/GlobalExceptionHandlerV2.java
+++ b/src/main/java/clov3r/oneit_server/error/exception/GlobalExceptionHandlerV2.java
@@ -7,6 +7,7 @@ import clov3r.oneit_server.service.SlackService;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,24 +50,26 @@ public class GlobalExceptionHandlerV2 extends ResponseEntityExceptionHandler {
   public ResponseEntity<Object> handleAllException(Exception exception) {
     log.warn("handleAllException", exception);
 
-    HashMap<String, String> data = new HashMap<>();
-    String msg = String.format("[API] ERROR\n" +
-            "env : %s \n" +
-            "uri : %s \n" +
-            "method : %s \n" +
-            "params : %s \n" +
-            "auth : %s \n" +
-            "exceptionMessage : %s \n" +
-            "exceptionStackTrace : %s \n",
-        MDC.get("env"),
-        MDC.get("uri"),
-        MDC.get("method"),
-        MDC.get("params"),
-        MDC.get("auth"),
-        exception.getMessage(),
-        Arrays.toString(exception.getStackTrace()).substring(0, 2000));
-    data.put(exception.getClass().getName(), msg);
-    slackService.sendMessage("IllegalAllException", data);
+    if (!Objects.equals(MDC.get("env"), "local")) {
+      HashMap<String, String> data = new HashMap<>();
+      String msg = String.format("[API] ERROR\n" +
+              "env : %s \n" +
+              "uri : %s \n" +
+              "method : %s \n" +
+              "params : %s \n" +
+              "auth : %s \n" +
+              "exceptionMessage : %s \n" +
+              "exceptionStackTrace : %s \n",
+          MDC.get("env"),
+          MDC.get("uri"),
+          MDC.get("method"),
+          MDC.get("params"),
+          MDC.get("auth"),
+          exception.getMessage(),
+          Arrays.toString(exception.getStackTrace()).substring(0, 2000));
+      data.put(exception.getClass().getName(), msg);
+      slackService.sendMessage("IllegalAllException", data);
+    }
 
     ErrorCode errorCode = CommonErrorCode.SERVER_ERROR;
     return handleExceptionInternal(errorCode);

--- a/src/main/java/clov3r/oneit_server/error/exception/GlobalExceptionHandlerV2.java
+++ b/src/main/java/clov3r/oneit_server/error/exception/GlobalExceptionHandlerV2.java
@@ -30,13 +30,13 @@ public class GlobalExceptionHandlerV2 extends ResponseEntityExceptionHandler {
     log.error("AuthException : {}, errorCode : {}", exception, errorCode, exception);
     return handleExceptionInternal(errorCode);
   }
-//
-//  @ExceptionHandler(BaseExceptionV2.class)
-//  public ResponseEntity<Object> handleBaseException(final BaseExceptionV2 exception) {
-//    final ErrorCode errorCode = exception.getErrorCode();
-//    log.error("BaseException : {}, errorCode : {}", exception, errorCode, exception);
-//    return handleExceptionInternal(errorCode, exception.getMessage());
-//  }
+
+  @ExceptionHandler(BaseExceptionV2.class)
+  public ResponseEntity<Object> handleBaseException(final BaseExceptionV2 exception) {
+    final ErrorCode errorCode = exception.getErrorCode();
+    log.error("BaseException : {}, errorCode : {}", exception, errorCode, exception);
+    return handleExceptionInternal(errorCode, exception.getMessage());
+  }
 
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException exception) {

--- a/src/main/java/clov3r/oneit_server/legacy/AuthController.java
+++ b/src/main/java/clov3r/oneit_server/legacy/AuthController.java
@@ -10,8 +10,8 @@ import clov3r.oneit_server.domain.data.status.UserStatus;
 import clov3r.oneit_server.domain.request.KakaoAccessToken;
 import clov3r.oneit_server.domain.entity.User;
 import clov3r.oneit_server.repository.AuthRepository;
-import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.legacy.response.BaseResponse;
+import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.service.AuthService;
 import clov3r.oneit_server.service.UserService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -41,9 +41,9 @@ public class AuthController {
         KakaoProfileDTO kakaoProfileDTO = authService.getKaKaoUserInfo(kakaoAccessToken.getAccessToken());
         User user;
         // check if the user exists
-        if (userRepository.existsUserByEmail(kakaoProfileDTO.getKakao_account().getEmail())) {
+        if (userRepository.existsByEmail(kakaoProfileDTO.getKakao_account().getEmail())) {
             // if so, return the user's access token (jwt)
-            user = userRepository.findUserByEmail(kakaoProfileDTO.getKakao_account().getEmail());
+            user = userRepository.findByEmail(kakaoProfileDTO.getKakao_account().getEmail());
             if (!user.getStatus().equals(UserStatus.ACTIVE)) {
                 user.setStatus(UserStatus.ACTIVE); 
             }

--- a/src/main/java/clov3r/oneit_server/legacy/GiftboxController.java
+++ b/src/main/java/clov3r/oneit_server/legacy/GiftboxController.java
@@ -13,9 +13,9 @@ import clov3r.oneit_server.domain.request.PostGiftboxRequest;
 import clov3r.oneit_server.domain.entity.Giftbox;
 import clov3r.oneit_server.repository.GiftboxRepository;
 import clov3r.oneit_server.repository.ProductRepository;
-import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.legacy.response.BaseResponse;
 import clov3r.oneit_server.legacy.exception.BaseException;
+import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.service.GiftboxService;
 import clov3r.oneit_server.service.S3Service;
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,7 +51,7 @@ public class GiftboxController {
       if (request.getName() == null || request.getDeadline() == null || userIdx == null) {
         return new BaseResponse<>(REQUEST_ERROR);
       }
-      if (!userRepository.existsUser(userIdx)) {
+      if (!userRepository.existsByUserIdx(userIdx)) {
         return new BaseResponse<>(USER_NOT_FOUND);
       }
       if (request.getDeadline().isBefore(LocalDateTime.now().toLocalDate())) {
@@ -107,7 +107,7 @@ public class GiftboxController {
               participant.getUser().getIdx(),
               participant.getUser().getNickname(),
               participant.getUser().getName(),
-              participant.getUser().getProfileImgFromKakao(),
+              participant.getUser().getProfileImg(),
               participant.getUserRole()
           ))
           .toList();
@@ -149,7 +149,7 @@ public class GiftboxController {
       @Parameter(hidden = true) @Auth Long userIdx
   ) {
     // request validation
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
 
@@ -165,7 +165,7 @@ public class GiftboxController {
                     participant.getUser().getIdx(),
                     participant.getUser().getNickname(),
                     participant.getUser().getName(),
-                    participant.getUser().getProfileImgFromKakao(),
+                    participant.getUser().getProfileImg(),
                     participant.getUserRole()
                 ))
                 .toList();
@@ -198,7 +198,7 @@ public class GiftboxController {
     if (giftboxRepository.findById(giftboxIdx) == null) {
       return new BaseResponse<>(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isManagerOfGiftbox(userIdx, giftboxIdx)) {
@@ -231,7 +231,7 @@ public class GiftboxController {
       if (request.getName() == null || request.getDeadline() == null || userIdx == null) {
         return new BaseResponse<>(REQUEST_ERROR);
       }
-      if (!userRepository.existsUser(userIdx)) {
+      if (!userRepository.existsByUserIdx(userIdx)) {
         return new BaseResponse<>(USER_NOT_FOUND);
       }
       if (!giftboxRepository.isManagerOfGiftbox(userIdx, giftboxIdx)) {
@@ -277,7 +277,7 @@ public class GiftboxController {
     if (!giftboxRepository.existsById(giftboxIdx)) {
       return new BaseResponse<>(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -317,7 +317,7 @@ public class GiftboxController {
     if (!giftboxRepository.existsById(giftboxUser.getGiftbox().getIdx())) {
       return new BaseResponse<>(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
 
@@ -343,7 +343,7 @@ public class GiftboxController {
     if (!giftboxRepository.existsById(giftboxIdx)) {
       return new BaseResponse<>(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -357,7 +357,7 @@ public class GiftboxController {
               participant.getUser().getIdx(),
               participant.getUser().getNickname(),
               participant.getUser().getName(),
-              participant.getUser().getProfileImgFromKakao(),
+              participant.getUser().getProfileImg(),
               participant.getUserRole()
           ))
           .toList();

--- a/src/main/java/clov3r/oneit_server/legacy/GiftboxProductController.java
+++ b/src/main/java/clov3r/oneit_server/legacy/GiftboxProductController.java
@@ -20,8 +20,8 @@ import clov3r.oneit_server.legacy.exception.BaseException;
 import clov3r.oneit_server.repository.GiftboxProductRepository;
 import clov3r.oneit_server.repository.GiftboxRepository;
 import clov3r.oneit_server.repository.ProductRepository;
-import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.legacy.response.BaseResponse;
+import clov3r.oneit_server.repository.UserRepository;
 import clov3r.oneit_server.service.GiftboxProductService;
 import clov3r.oneit_server.service.GiftboxService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -68,7 +68,7 @@ public class GiftboxProductController {
         return new BaseResponse<>(PRODUCT_NOT_FOUND);
       }
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -152,7 +152,7 @@ public class GiftboxProductController {
     if (giftboxRepository.findById(giftboxIdx) == null) {
       return new BaseResponse<>(GIFTBOX_NOT_FOUND);
     }
-    if (!userRepository.existsUser(userIdx)) {
+    if (!userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
@@ -206,7 +206,7 @@ public class GiftboxProductController {
 //    }
 
     // 로그인 유저만 가능한 경우
-    if (userIdx == null || !userRepository.existsUser(userIdx)) {
+    if (userIdx == null || !userRepository.existsByUserIdx(userIdx)) {
       return new BaseResponse<>(USER_NOT_FOUND);
     }
     if (!giftboxRepository.isParticipantOfGiftbox(userIdx, request.getGiftboxIdx())) {

--- a/src/main/java/clov3r/oneit_server/repository/UserRepository.java
+++ b/src/main/java/clov3r/oneit_server/repository/UserRepository.java
@@ -1,55 +1,19 @@
 package clov3r.oneit_server.repository;
 
-import static clov3r.oneit_server.domain.entity.QUser.user;
-
-import clov3r.oneit_server.domain.data.status.Status;
-import clov3r.oneit_server.domain.data.status.UserStatus;
 import clov3r.oneit_server.domain.entity.User;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-@Repository
-@RequiredArgsConstructor
-public class UserRepository {
+public interface UserRepository extends JpaRepository<User, Long> {
 
-    private final EntityManager em;
-    private final JPAQueryFactory queryFactory;
+  @Query("select count(u) > 0 from User u where u.idx = :userIdx and u.status = 'ACTIVE'")
+  boolean existsByUserIdx(Long userIdx);
 
-    public void save(User user) {
-        em.persist(user);
-    }
-    public boolean existsUser(Long userIdx) {
-        // status가 ACTIVE인 user가 존재하는지 확인
-        return queryFactory.selectOne()
-                .from(user)
-                .where(user.idx.eq(userIdx)
-                        .and(user.status.eq(UserStatus.ACTIVE)))
-                .fetchFirst() != null;
+  boolean existsByEmail(String email);
 
-    }
+  User findByEmail(String email);
 
-    public User findUser(Long userIdx) {
-        return em.find(User.class, userIdx);
-    }
-
-
-    public boolean existsUserByEmail(String email) {
-        return em.createQuery("select count(u) > 0 from User u where u.email = :email", Boolean.class)
-                .setParameter("email", email)
-                .getSingleResult();
-    }
-
-    public User findUserByEmail(String email) {
-        return em.createQuery("select u from User u where u.email = :email", User.class)
-                .setParameter("email", email)
-                .getSingleResult();
-    }
-
-    public User findById(Long userIdx) {
-        return em.find(User.class, userIdx);
-    }
+  @Query("select u from User u where u.idx = :userIdx and u.status = 'ACTIVE'")
+  User findByUserIdx(Long userIdx);
 
 }

--- a/src/main/java/clov3r/oneit_server/service/AuthService.java
+++ b/src/main/java/clov3r/oneit_server/service/AuthService.java
@@ -1,9 +1,13 @@
 package clov3r.oneit_server.service;
 
+import static clov3r.oneit_server.error.errorcode.CustomErrorCode.USER_NOT_FOUND;
+
 import clov3r.oneit_server.domain.DTO.KakaoFriendDTO;
 import clov3r.oneit_server.domain.data.status.UserStatus;
 import clov3r.oneit_server.domain.entity.User;
 import clov3r.oneit_server.domain.DTO.KakaoProfileDTO;
+import clov3r.oneit_server.domain.request.SignupRequest;
+import clov3r.oneit_server.error.exception.BaseExceptionV2;
 import clov3r.oneit_server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;

--- a/src/main/java/clov3r/oneit_server/service/FriendService.java
+++ b/src/main/java/clov3r/oneit_server/service/FriendService.java
@@ -1,7 +1,7 @@
 package clov3r.oneit_server.service;
 
 import clov3r.oneit_server.domain.DTO.FriendReqDTO;
-import clov3r.oneit_server.domain.DTO.UserDTO;
+import clov3r.oneit_server.domain.DTO.FriendDTO;
 import clov3r.oneit_server.domain.data.status.FriendReqStatus;
 import clov3r.oneit_server.domain.data.status.Status;
 import clov3r.oneit_server.domain.entity.FriendReq;
@@ -25,8 +25,8 @@ public class FriendService {
   public FriendReq requestFriend(Long userIdx, Long friendIdx) {
 
     FriendReq friendReq = FriendReq.builder()
-        .from(userRepository.findById(userIdx))
-        .to(userRepository.findById(friendIdx))
+        .from(userRepository.findByUserIdx(userIdx))
+        .to(userRepository.findByUserIdx(friendIdx))
         .friendReqStatus(FriendReqStatus.REQUESTED)
         .build();
     friendReq.createBaseEntity();
@@ -44,12 +44,12 @@ public class FriendService {
   @Transactional
   public void createNewFriendship(Long userIdx, Long friendIdx) {
     Friendship friendshipA = Friendship.builder()
-        .user(userRepository.findById(userIdx))
-        .friend(userRepository.findById(friendIdx))
+        .user(userRepository.findByUserIdx(userIdx))
+        .friend(userRepository.findByUserIdx(friendIdx))
         .build();
     Friendship friendshipB = Friendship.builder()
-        .user(userRepository.findById(friendIdx))
-        .friend(userRepository.findById(userIdx))
+        .user(userRepository.findByUserIdx(friendIdx))
+        .friend(userRepository.findByUserIdx(userIdx))
         .build();
     friendshipA.setStatus(Status.ACTIVE);
     friendshipB.setStatus(Status.ACTIVE);
@@ -88,11 +88,11 @@ public class FriendService {
   public List<FriendReqDTO> getFriendRequestsToMe(Long userIdx) {
     List<FriendReq> friendReqs = friendReqRepository.findAllByToIdx(userIdx);
     List<FriendReqDTO> friendReqDTOList = friendReqs.stream().map(friendReq -> {
-      UserDTO fromUser = UserDTO.builder()
+      FriendDTO fromUser = FriendDTO.builder()
           .idx(friendReq.getFrom().getIdx())
           .name(friendReq.getFrom().getName())
           .nickName(friendReq.getFrom().getNickname())
-          .profileImg(friendReq.getFrom().getProfileImgFromKakao())
+          .profileImg(friendReq.getFrom().getProfileImg())
           .birthDate(friendReq.getFrom().getBirthDate())
           .build();
       return new FriendReqDTO(friendReq.getIdx(), fromUser, friendReq.getCreatedAt());
@@ -103,11 +103,11 @@ public class FriendService {
   public List<FriendReqDTO> getFriendRequestsFromMe(Long userIdx) {
     List<FriendReq> friendReqs = friendReqRepository.findAllByFromIdx(userIdx);
     List<FriendReqDTO> friendReqDTOList = friendReqs.stream().map(friendReq -> {
-      UserDTO ToUser = UserDTO.builder()
+      FriendDTO ToUser = FriendDTO.builder()
           .idx(friendReq.getTo().getIdx())
           .name(friendReq.getTo().getName())
           .nickName(friendReq.getTo().getNickname())
-          .profileImg(friendReq.getTo().getProfileImgFromKakao())
+          .profileImg(friendReq.getTo().getProfileImg())
           .birthDate(friendReq.getTo().getBirthDate())
           .build();
       return new FriendReqDTO(friendReq.getIdx(), ToUser, friendReq.getCreatedAt());
@@ -116,14 +116,14 @@ public class FriendService {
   }
 
 
-  public List<UserDTO> getFriends(Long userIdx) {
+  public List<FriendDTO> getFriends(Long userIdx) {
     List<Friendship> friendshipsList = friendshipRepository.findByUserIdx(userIdx);
     return friendshipsList.stream()
-        .map(friendship -> UserDTO.builder()
+        .map(friendship -> FriendDTO.builder()
             .idx(friendship.getFriend().getIdx())
             .name(friendship.getFriend().getName())
             .nickName(friendship.getFriend().getNickname())
-            .profileImg(friendship.getFriend().getProfileImgFromKakao())
+            .profileImg(friendship.getFriend().getProfileImg())
             .birthDate(friendship.getFriend().getBirthDate())
             .build())
         .toList();

--- a/src/main/java/clov3r/oneit_server/service/InquiryService.java
+++ b/src/main/java/clov3r/oneit_server/service/InquiryService.java
@@ -1,15 +1,11 @@
 package clov3r.oneit_server.service;
 
-import clov3r.oneit_server.domain.data.ProductEmoji;
 import clov3r.oneit_server.domain.data.status.InquiryStatus;
 import clov3r.oneit_server.domain.entity.Giftbox;
 import clov3r.oneit_server.domain.entity.GiftboxInquiryResult;
 import clov3r.oneit_server.domain.entity.Inquiry;
 import clov3r.oneit_server.domain.entity.Product;
-import clov3r.oneit_server.domain.entity.User;
 import clov3r.oneit_server.domain.request.InquiryRequest;
-import clov3r.oneit_server.error.errorcode.CustomErrorCode;
-import clov3r.oneit_server.error.exception.BaseExceptionV2;
 import clov3r.oneit_server.repository.GiftboxRepository;
 import clov3r.oneit_server.repository.InquiryProductRepository;
 import clov3r.oneit_server.repository.InquiryRepository;
@@ -34,7 +30,7 @@ public class InquiryService {
   public Long createInquiry(InquiryRequest inquiryRequest, Long userIdx) {
     Inquiry inquiry = new Inquiry(
         giftboxRepository.findById(inquiryRequest.getGiftboxIdx()),
-        userRepository.findUser(userIdx),
+        userRepository.findByUserIdx(userIdx),
         InquiryStatus.ACTIVE,
         inquiryRequest.getTarget()
     );

--- a/src/main/java/clov3r/oneit_server/service/UserService.java
+++ b/src/main/java/clov3r/oneit_server/service/UserService.java
@@ -1,9 +1,14 @@
 package clov3r.oneit_server.service;
 
+import static clov3r.oneit_server.error.errorcode.CustomErrorCode.USER_NOT_FOUND;
+
 import clov3r.oneit_server.domain.entity.User;
+import clov3r.oneit_server.domain.request.SignupRequest;
+import clov3r.oneit_server.error.exception.BaseExceptionV2;
 import clov3r.oneit_server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,7 +17,22 @@ public class UserService {
     private final UserRepository userRepository;
 
     public User getUser(Long userIdx) {
-        return userRepository.findUser(userIdx);
+        return userRepository.findByUserIdx(userIdx);
+    }
+
+    @Transactional
+    public User signUp(SignupRequest signupRequest, Long userIdx) {
+        User user = userRepository.findByUserIdx(userIdx);
+        System.out.println("user = " + user);
+        if (user == null) {
+            throw new BaseExceptionV2(USER_NOT_FOUND);
+        }
+        user.setName(signupRequest.getName());
+        user.setNickname(signupRequest.getNickname());
+        user.setGender(signupRequest.getGender());
+        user.setBirthDate(signupRequest.getBirthDate());
+        userRepository.save(user);
+        return user;
     }
 
 }

--- a/src/main/java/clov3r/oneit_server/service/UserService.java
+++ b/src/main/java/clov3r/oneit_server/service/UserService.java
@@ -23,7 +23,6 @@ public class UserService {
     @Transactional
     public User signUp(SignupRequest signupRequest, Long userIdx) {
         User user = userRepository.findByUserIdx(userIdx);
-        System.out.println("user = " + user);
         if (user == null) {
             throw new BaseExceptionV2(USER_NOT_FOUND);
         }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -10,10 +10,6 @@
       <appender-ref ref="CONSOLE"/>
     </root>
 
-    <include resource="log/file-info-appender.xml"/>
-    <root level="INFO">
-      <appender-ref ref="FILE-INFO"/>
-    </root>
   </springProfile>
 
   <!--dev-->


### PR DESCRIPTION
# [ONE-688] 자체 회원가입 API
## 🔑 Key Change 
- 카카오 로그인 이후 추가정보 수집하기 위한 자체 회원가입 API
- 수집 정보 : 이름, 닉네임, 성별, 생년월일
- 카카오 로그인 이후 응답받은 자체 액세스 토큰을 헤더에 넘겨주면 됨
- 액세스 토큰에서 userIdx를 뽑아서 해당 user의 정보를 업데이트 시키는 방식

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 

논의할 것 : 카카오 로그인 -> 자체 회원가입 로직
현재는 카카오 로그인하면 일단 user 정보가 DB에 저장됨, 그 후 회원가입 API로 정보가 업데이트 되는 방식
이 경우 회원가입하면 추가 정보 입력하는게 필수가 아니게 됨

그래서 카카오 로그인 + 자체 회원가입 을 묶어서 추가 정보까지 입력해야 로그인 성공하고 액세스 토큰 넘겨주도록 수정할지 아님 이대로 갈지
카카오 비즈니스로 바꾸면 추가 정보를 카카오에서 받아올 수 있지만, 시간이 걸릴 수 있으니 일단 자체적으로 만듦.



[ONE-688]: https://clov3r.atlassian.net/browse/ONE-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ