### PR TITLE
Feature/fcm - FCM 연동하여 유저 로그인 시 디바이스 토큰을 저장, 친구 요청 및 수락 시 알림 전송

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -17,6 +17,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: firebase notification
+        run: |
+          mkdir -p firebase
+          echo "${{ secrets.FCM_ACCOUNT }}" > ./firebase/firebase-admin-sdk.json
+        shell: bash
+
       # gradle 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 application-local.yml
 
 /logs
+**/firebase

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
 
     // slack
     implementation("com.slack.api:slack-api-client:1.40.0")
+
+    // Google Firebase Admin
+    implementation("com.google.firebase:firebase-admin:9.2.0")
+
 }
 //tasks.withType<Test> {
 //    useJUnitPlatform()

--- a/src/main/java/clov3r/oneit_server/config/FirebaseConfig.java
+++ b/src/main/java/clov3r/oneit_server/config/FirebaseConfig.java
@@ -1,0 +1,32 @@
+package clov3r.oneit_server.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import java.io.InputStream;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class FirebaseConfig {
+
+  @Value("${fcm.config.path}")
+  private String firebaseConfigFile;
+  @PostConstruct
+  public void init(){
+    try{
+      InputStream serviceAccount = new ClassPathResource("firebase/"+firebaseConfigFile).getInputStream();
+      FirebaseOptions options = new FirebaseOptions.Builder()
+          .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+          .build();
+
+      if (FirebaseApp.getApps().isEmpty()) { // FirebaseApp이 이미 초기화되어 있지 않은 경우에만 초기화 실행
+        FirebaseApp.initializeApp(options);
+      }
+    } catch (Exception e){
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/clov3r/oneit_server/controller/FriendController.java
+++ b/src/main/java/clov3r/oneit_server/controller/FriendController.java
@@ -12,9 +12,11 @@ import clov3r.oneit_server.domain.entity.FriendReq;
 import clov3r.oneit_server.error.exception.BaseExceptionV2;
 import clov3r.oneit_server.repository.FriendReqRepository;
 import clov3r.oneit_server.service.FriendService;
+import clov3r.oneit_server.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -37,7 +39,7 @@ public class FriendController {
   public ResponseEntity<RequestFriendDTO> requestFriend(
       @PathVariable Long friendIdx,
       @Parameter(hidden = true) @Auth Long userIdx
-  ) {
+  ) throws IOException {
     if (userIdx.equals(friendIdx)) {
       throw new BaseExceptionV2(INVALID_SELF_REQUEST);
     }
@@ -59,7 +61,7 @@ public class FriendController {
       @PathVariable Long friendIdx,
       @PathVariable Long requestIdx,
       @Parameter(hidden = true) @Auth Long userIdx
-  ) {
+  ) throws IOException {
     friendService.acceptFriend(requestIdx);
     if (!friendService.isFriend(userIdx, friendIdx)) {
       friendService.createNewFriendship(userIdx, friendIdx);

--- a/src/main/java/clov3r/oneit_server/controller/NotificationController.java
+++ b/src/main/java/clov3r/oneit_server/controller/NotificationController.java
@@ -1,0 +1,68 @@
+package clov3r.oneit_server.controller;
+
+import clov3r.oneit_server.config.security.Auth;
+import clov3r.oneit_server.repository.DeviceRepository;
+import clov3r.oneit_server.service.FCMService;
+import clov3r.oneit_server.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/notification")
+public class NotificationController {
+
+  private final FCMService fcmService;
+  private final NotificationService notificationService;
+
+  @Tag(name = "알림 API", description = "알림 관련 API")
+  @Operation(summary = "FCM 토큰 저장", description = "유저 로그인시 알림 허용을 했다면, FCM 토큰을 저장합니다.")
+  @GetMapping("/token")
+  public void sendFCMNotification(
+      @RequestParam String token,
+      @Parameter(hidden = true) @Auth Long userIdx
+  ) throws IOException {
+    String title = "FCM TEST";
+    String body = "안녕하십니까!";
+    fcmService.sendMessageTo(token, title, body);
+    notificationService.saveDeviceToken(userIdx, token);
+  }
+
+  @Tag(name = "알림 API", description = "알림 관련 API")
+  @Operation(summary = "알림 리스트 조회", description = "알림 리스트를 조회합니다.")
+  @GetMapping("/list")
+  public void getNotificationList(
+      @Parameter(hidden = true) @Auth Long userIdx
+  ) {
+    notificationService.getNotificationList(userIdx);
+  }
+
+  @Tag(name = "알림 API", description = "알림 관련 API")
+  @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
+  @PatchMapping("/read")
+  public void readNotification(
+      @RequestParam Long notificationIdx
+  ) {
+    notificationService.readNotification(notificationIdx);
+  }
+
+//
+//  @Tag(name = "FCM API", description = "FCM 관련 API")
+//  @GetMapping("/fcm")
+//  public void sendFcm(
+//      @RequestParam String token
+//  ) throws IOException {
+//    String title = "FCM TEST";
+//    String body = "안녕하십니까!";
+//    fcmService.sendMessageTo(token, title, body);
+//  }
+
+}

--- a/src/main/java/clov3r/oneit_server/domain/DTO/FcmMessageDTO.java
+++ b/src/main/java/clov3r/oneit_server/domain/DTO/FcmMessageDTO.java
@@ -1,0 +1,39 @@
+package clov3r.oneit_server.domain.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class FcmMessageDTO {
+  private boolean    validateOnly;
+  private Message    message;
+
+  @Builder
+  @AllArgsConstructor
+  @Getter
+  public static class Message {
+    private Notification notification;
+    private String      token;
+    private Data        data;
+  }
+
+  @Builder
+  @AllArgsConstructor
+  @Getter
+  public static class Notification {
+    private String  title;
+    private String  body;
+  }
+
+  @Builder
+  @AllArgsConstructor
+  @Getter
+  public static class Data{
+    private String    name;
+    private String    description;
+  }
+
+}

--- a/src/main/java/clov3r/oneit_server/domain/DTO/PushNotificationRequest.java
+++ b/src/main/java/clov3r/oneit_server/domain/DTO/PushNotificationRequest.java
@@ -1,0 +1,7 @@
+package clov3r.oneit_server.domain.DTO;
+
+public class PushNotificationRequest {
+  private String token;
+  private String title;
+  private String body;
+}

--- a/src/main/java/clov3r/oneit_server/domain/entity/Device.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/Device.java
@@ -1,0 +1,43 @@
+package clov3r.oneit_server.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@Table(name = "device")
+public class Device {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long idx;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_idx")
+  private User user;
+
+  @Column(name = "device_token")
+  private String deviceToken;
+
+  @Column(name = "last_logged_in_at")
+  private LocalDateTime lastLoggedInAt;
+
+  public Device() {
+
+  }
+  public void updateLoginAt(LocalDateTime now) {
+    this.lastLoggedInAt = now;
+  }
+}

--- a/src/main/java/clov3r/oneit_server/domain/entity/FriendReq.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/FriendReq.java
@@ -20,7 +20,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Table(name = "friend_req")
-public class FriendReq extends BaseEntity{
+public class FriendReq extends BaseEntity {
 
   @Id @GeneratedValue(strategy = IDENTITY)
   private Long idx;

--- a/src/main/java/clov3r/oneit_server/domain/entity/Notification.java
+++ b/src/main/java/clov3r/oneit_server/domain/entity/Notification.java
@@ -1,0 +1,41 @@
+package clov3r.oneit_server.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notification {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long idx;
+
+  @ManyToOne
+  @JoinColumn(name = "user_idx")
+  private User user;
+  private String title;
+  private String body;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Setter
+  private LocalDateTime readAt;
+
+
+
+}

--- a/src/main/java/clov3r/oneit_server/repository/DeviceRepository.java
+++ b/src/main/java/clov3r/oneit_server/repository/DeviceRepository.java
@@ -1,0 +1,14 @@
+package clov3r.oneit_server.repository;
+
+import clov3r.oneit_server.domain.entity.Device;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+  @Query("select d from Device d where d.user.idx = :userIdx")
+  Device findByUserId(Long userIdx);
+
+}

--- a/src/main/java/clov3r/oneit_server/repository/NotificationRepository.java
+++ b/src/main/java/clov3r/oneit_server/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package clov3r.oneit_server.repository;
+
+import clov3r.oneit_server.domain.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  @Query("SELECT n FROM Notification n WHERE n.user.idx = :userIdx and n.readAt = null")
+  void findAllByUserId(Long userIdx);
+
+}

--- a/src/main/java/clov3r/oneit_server/service/FCMService.java
+++ b/src/main/java/clov3r/oneit_server/service/FCMService.java
@@ -1,0 +1,73 @@
+package clov3r.oneit_server.service;
+
+import clov3r.oneit_server.domain.DTO.FcmMessageDTO;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FCMService {
+
+  ObjectMapper objectMapper = new ObjectMapper();
+  @Value("${fcm.base-url}")
+  String API_URL;
+  @Value("${fcm.auth-url}")
+  String AUTH_URL;
+  @Value("${fcm.config.path}")
+  String firebaseConfigPath;
+
+  @PostConstruct
+  private String getAccessToken() throws IOException {
+
+    GoogleCredentials googleCredentials = GoogleCredentials
+        .fromStream(new ClassPathResource("firebase/"+firebaseConfigPath).getInputStream())
+        .createScoped(List.of(AUTH_URL));
+
+    googleCredentials.refreshIfExpired();
+    return googleCredentials.getAccessToken().getTokenValue();
+  }
+
+  private String makeMessage(String token, String title, String body) throws JsonParseException, JsonProcessingException {
+    FcmMessageDTO fcmMessage = FcmMessageDTO.builder()
+        .message(FcmMessageDTO.Message.builder()
+            .token(token)
+            .notification(FcmMessageDTO.Notification.builder()
+                .title(title)
+                .body(body)
+                .build()
+            ).build()).validateOnly(false).build();
+
+    return objectMapper.writeValueAsString(fcmMessage);
+  }
+
+  public void sendMessageTo(String targetToken, String title, String body) throws IOException {
+    String message = makeMessage(targetToken, title, body);
+
+    OkHttpClient client = new OkHttpClient();
+
+    RequestBody requestBody = RequestBody.create(message,
+        MediaType.get("application/json; charset=utf-8"));
+    Request request = new Request.Builder()
+        .url(API_URL)
+        .post(requestBody)
+        .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+        .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+        .build();
+
+    Response response = client.newCall(request).execute();
+  }
+
+}

--- a/src/main/java/clov3r/oneit_server/service/NotificationService.java
+++ b/src/main/java/clov3r/oneit_server/service/NotificationService.java
@@ -1,0 +1,69 @@
+package clov3r.oneit_server.service;
+
+import clov3r.oneit_server.domain.entity.Device;
+import clov3r.oneit_server.domain.entity.FriendReq;
+import clov3r.oneit_server.domain.entity.Notification;
+import clov3r.oneit_server.repository.DeviceRepository;
+import clov3r.oneit_server.repository.NotificationRepository;
+import clov3r.oneit_server.repository.UserRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
+  private final DeviceRepository deviceRepository;
+
+  @Transactional
+  public void saveDeviceToken(Long userIdx, String token) {
+    Device device = deviceRepository.findByUserId(userIdx);
+    if (device != null) {
+      device.updateLoginAt(LocalDateTime.now());
+    } else {
+      device = Device.builder()
+          .user(userRepository.findByUserIdx(userIdx))
+          .deviceToken(token)
+          .lastLoggedInAt(LocalDateTime.now())
+          .build();
+      deviceRepository.save(device);
+    }
+  }
+
+  public void sendFreindRequestNotification(FriendReq friendReq) {
+    Notification notification = Notification.builder()
+        .user(friendReq.getTo())
+        .title("친구 요청")
+        .body(friendReq.getFrom().getNickname() + "님이 친구 요청을 보냈습니다.")
+        .createdAt(LocalDateTime.now())
+        .build();
+    notificationRepository.save(notification);
+  }
+
+  public void sendFriendAcceptanceNotification(FriendReq friendReq) {
+    Notification notification = Notification.builder()
+        .user(friendReq.getFrom())
+        .title("친구 요청 수락")
+        .body(friendReq.getTo().getNickname() + "님이 친구 요청을 수락했습니다.")
+        .createdAt(LocalDateTime.now())
+        .build();
+    notificationRepository.save(notification);
+  }
+
+  public void getNotificationList(Long userIdx) {
+
+    notificationRepository.findAllByUserId(userIdx);
+  }
+
+  @Transactional
+  public void readNotification(Long notificationIdx) {
+
+    Notification notification = notificationRepository.findById(notificationIdx).orElseThrow();
+    notification.setReadAt(LocalDateTime.now());
+    notificationRepository.save(notification);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,6 @@ webhook:
 
 fcm:
   config:
-    path: ${FIREBASE_ADMIN_SDK_CONFIG_FILE}
+    path: firebase-admin-sdk.json
   base-url: https://fcm.googleapis.com/v1/projects/oneit-gpt/messages:send
   auth-url: https://www.googleapis.com/auth/cloud-platform

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,8 @@ webhook:
   slack:
     url: ${WEBHOOK_SLACK_URL}
 
+fcm:
+  config:
+    path: ${FIREBASE_ADMIN_SDK_CONFIG_FILE}
+  base-url: https://fcm.googleapis.com/v1/projects/oneit-gpt/messages:send
+  auth-url: https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
# [ONE-774] FCM 알림 연동
## 🔑 Key Change 
- FCM 초기 연결 설정
- 로그인 시 알림 허용했다면 user access token과 함께 device토큰을 입력받아 DB에 저장(FCM 토큰 저장 API)
- 해당 유저에게 전송할 알림 리스트 조회 API (읽음 처리 되지 않은 것만 조회됨)
- 알림 읽음 처리 API
- 이후 친구 요청시 요청받은 친구에게 알림 전송
- 친구 수락시 요청한 친구에게 알림 전송

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 
- 기본적인 FCM 알림 설정 개발함
- 친구 요청 및 수락에 대해서 일단 바로 알림 가도록 개발함
- 이후 비동기 알림으로 부하를 줄이는 방법으로 개선 예정
- FCM 관련 private key를 git actions에서 주입하도록 ci/cd 구현함


[ONE-774]: https://clov3r.atlassian.net/browse/ONE-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ