### PR TITLE
[build] 에러 로그 트래킹을 위한 Sentry 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,9 @@ dependencies {
     // Google Firebase Admin
     implementation("com.google.firebase:firebase-admin:9.2.0")
 
+    // Sentry
+    implementation("io.sentry:sentry-spring-boot-starter-jakarta:7.9.0")
+
 }
 //tasks.withType<Test> {
 //    useJUnitPlatform()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,3 +11,10 @@ spring:
 
 jwt:
   secret_key: ${DEV_JWT_SECRET_KEY}
+
+sentry:
+  dsn: "${SENTRY_DSN}"
+  exception-resolver-order: -2147483647
+  max-request-body-size: always
+  send-default-pii: true
+  traces-sample-rate: 1.0

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,3 +12,9 @@ spring:
 jwt:
   secret_key: ${PROD_JWT_SECRET_KEY}
 
+sentry:
+  dsn: "${SENTRY_DSN}"
+  exception-resolver-order: -2147483647
+  max-request-body-size: always
+  send-default-pii: true
+  traces-sample-rate: 1.0


### PR DESCRIPTION
# [ONE-XX] Sentry 연결
## 🔑 Key Change 
- 에러 발생시 GUI로 에러 로그 표시
- dev와 prod 각각 연결

## 🖼️ Screenshots (if necessary)
<img width="642" alt="image" src="https://github.com/user-attachments/assets/4f0d5b50-3cfd-4f17-a471-9c187c6884a0">

## 🙏 To Reviewers
🧑‍🤝‍🧑 @Teammate_name
- remark 1
