### PR TITLE
Feature/giftbox - 선물바구니 초대 수락시 FCM 알림 및 회원가입 완료 시 카카오 알림톡 전송

### DIFF
--- a/api/src/main/java/clov3r/api/controller/AuthControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/AuthControllerV2.java
@@ -19,6 +19,7 @@ import clov3r.api.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,7 +50,8 @@ public class AuthControllerV2 {
             // 1. 이미 카카오 가입된 유저라면 status를 active로 변경
             user = userRepository.findByEmail(kakaoProfileDTO.getKakao_account().getEmail());
             if (!user.getStatus().equals(UserStatus.ACTIVE)) {
-                user.setStatus(UserStatus.ACTIVE); 
+                user.setStatus(UserStatus.ACTIVE);
+                user.setUpdatedAt(LocalDateTime.now());
             }
             // 2. 자체 회원가입 유무 확인
             if (user.getName()!=null && user.getNickname()!=null && user.getGender()!=null && user.getBirthDate()!=null) {
@@ -120,6 +122,16 @@ public class AuthControllerV2 {
             .birthDate(user.getBirthDate())
             .build();
         return ResponseEntity.ok(newUser);
+    }
+
+    @Tag(name = "계정 API", description = "회원가입/로그인 관련 API 목록")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
+    @PostMapping("/api/v2/withdraw")
+    public ResponseEntity<String> withdraw(
+        @Parameter(hidden = true) @Auth Long userIdx
+    ) {
+        userService.withdraw(userIdx);
+        return ResponseEntity.ok("탈퇴가 완료되었습니다.");
     }
 
 }

--- a/api/src/main/java/clov3r/api/controller/GiftboxControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/GiftboxControllerV2.java
@@ -19,9 +19,11 @@ import clov3r.api.domain.data.status.AccessStatus;
 import clov3r.api.domain.data.status.InvitationStatus;
 import clov3r.api.domain.entity.Giftbox;
 import clov3r.api.domain.entity.GiftboxUser;
+import clov3r.api.domain.entity.Notification;
 import clov3r.api.domain.request.PostGiftboxRequest;
 import clov3r.api.error.exception.BaseExceptionV2;
 import clov3r.api.repository.GiftboxRepository;
+import clov3r.api.repository.NotificationRepository;
 import clov3r.api.repository.ProductRepository;
 import clov3r.api.repository.UserRepository;
 import clov3r.api.service.GiftboxService;
@@ -33,6 +35,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -53,8 +56,7 @@ public class GiftboxControllerV2 {
   private final GiftboxRepository giftboxRepository;
   private final S3Service s3Service;
   private final UserRepository userRepository;
-  private final ProductRepository productRepository;
-  private final NotificationService notificationService;
+
 
   @Tag(name = "선물바구니 API", description = "선물바구니 CRUD API 목록")
   @Operation(summary = "선물바구니 생성", description = "선물 바구니 생성, 이미지는 선택적으로 업로드 가능, 이미지를 업로드하지 않을 경우 null로 저장")
@@ -304,11 +306,7 @@ public class GiftboxControllerV2 {
     }
 
     // accept invitation to giftbox
-    giftboxRepository.acceptInvitationToGiftBox(userIdx, invitationIdx);
-
-    // send notification
-//    notificationService.sendGiftboxInvitationAcceptanceNotification(giftboxUser.getGiftbox().getIdx(), userIdx);
-
+    giftboxService.acceptInvitationToGiftBox(giftboxUser, userIdx, invitationIdx);
     return ResponseEntity.ok(
         "유저 " + userIdx + "님이 " + giftboxUser.getGiftbox().getIdx() + "번 선물 바구니에 참여하였습니다.");
   }

--- a/api/src/main/java/clov3r/api/controller/GiftboxProductControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/GiftboxProductControllerV2.java
@@ -90,16 +90,15 @@ public class GiftboxProductControllerV2 {
     if (giftboxIdx == null) {
       throw new BaseExceptionV2(REQUEST_ERROR);
     }
-    if (giftboxRepository.findById(giftboxIdx) == null) {
-      throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
-    }
-
     // check if the user is a participant of the giftbox
     Giftbox giftbox = giftboxRepository.findById(giftboxIdx);
+    if (giftbox == null) {
+      throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
+    }
     if (giftbox.getAccessStatus().equals(AccessStatus.PRIVATE)) {
       if (userIdx == null || !giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
-        throw new BaseExceptionV2(
-            NOT_PARTICIPANT_OF_GIFTBOX);  // 선물 바구니가 PRIVATE 일 경우, 해당 선물 바구니의 참여자만 조회 가능함
+        // 선물 바구니가 PRIVATE 일 경우, 해당 선물 바구니의 참여자만 조회 가능함
+        throw new BaseExceptionV2(NOT_PARTICIPANT_OF_GIFTBOX);
       }
     }
 

--- a/api/src/main/java/clov3r/api/domain/DTO/kakao/KakaoAlarmBodyDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/kakao/KakaoAlarmBodyDTO.java
@@ -1,0 +1,33 @@
+package clov3r.api.domain.DTO.kakao;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class KakaoAlarmBodyDTO {
+  private long service;
+  private String message;
+  private String mobile;
+  private String template;
+  private List<KakaoButton> buttons;
+
+  @Override
+  public String toString() {
+    return "KakaoAlarmBodyDTO{" +
+        "service=" + service +
+        ", message='" + message + '\'' +
+        ", mobile='" + mobile + '\'' +
+        ", template='" + template + '\'' +
+        ", buttons=" + buttons +
+        '}';
+  }
+
+}

--- a/api/src/main/java/clov3r/api/domain/DTO/kakao/KakaoAlarmResponseDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/kakao/KakaoAlarmResponseDTO.java
@@ -1,0 +1,10 @@
+package clov3r.api.domain.DTO.kakao;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoAlarmResponseDTO {
+  private String uid;
+  private String status;
+  private String date;
+}

--- a/api/src/main/java/clov3r/api/domain/DTO/kakao/KakaoButton.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/kakao/KakaoButton.java
@@ -1,0 +1,13 @@
+package clov3r.api.domain.DTO.kakao;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoButton {
+  private String name;
+  private String type;
+  private String url_pc;
+  private String url_mobile;
+}

--- a/api/src/main/java/clov3r/api/domain/data/kakao/KakaoAlarmTemplate.java
+++ b/api/src/main/java/clov3r/api/domain/data/kakao/KakaoAlarmTemplate.java
@@ -1,0 +1,26 @@
+package clov3r.api.domain.data.kakao;
+
+import clov3r.api.domain.DTO.kakao.KakaoButton;
+import clov3r.api.domain.entity.Notification;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoAlarmTemplate {
+
+  String templateCode;
+  String templateName;
+  String message;
+  List<KakaoButton> buttons;
+
+  public String makeMessage(Notification notification, String customerInquiry) {
+    return this.message;
+  }
+
+
+}

--- a/api/src/main/java/clov3r/api/domain/data/kakao/signupCompleteTemplate.java
+++ b/api/src/main/java/clov3r/api/domain/data/kakao/signupCompleteTemplate.java
@@ -1,0 +1,34 @@
+package clov3r.api.domain.data.kakao;
+
+import clov3r.api.domain.DTO.kakao.KakaoButton;
+import clov3r.api.domain.entity.Notification;
+import java.util.ArrayList;
+
+public class signupCompleteTemplate extends KakaoAlarmTemplate {
+  public signupCompleteTemplate() {
+    this.templateCode = "10001";
+    this.templateName = "회원가입 완료";
+    KakaoButton button1 = KakaoButton.builder()
+        .name("선물 추천 받기")
+        .type("WL")
+        .url_pc("https://www.oneit.gift/recommend")
+        .url_mobile("https://www.oneit.gift/recommend")
+        .build();
+    KakaoButton button2 = KakaoButton.builder()
+        .name("선물 고르기")
+        .type("WL")
+        .url_pc("https://www.oneit.gift")
+        .url_mobile("https://www.oneit.gift")
+        .build();
+    this.buttons = new ArrayList<>();
+    this.buttons.add(button1);
+    this.buttons.add(button2);
+  }
+
+  @Override
+  public String makeMessage(Notification notification, String customerInquiry) {
+    this.message = "[ONEIT] 회원가입 완료\nWANNA GIFT IT, ONE IT \uD83C\uDF89\n안녕하세요. "+notification.getReceiver().getNickname()+"님!\n\n선물을 원하는 당신을 위한 단 하나의 행동 패턴\nONEIT 회원가입이 완료되었습니다!\n친구에게 줄 선물 추천도 받아보고 \uD83C\uDF81\n선물바구니를 만들어 선물 비교도 한 눈에 해보세요! \uD83D\uDD0D\n\n\n⏩\uFE0F 고객문의 "+customerInquiry;
+    return this.message;
+  }
+
+}

--- a/api/src/main/java/clov3r/api/error/errorcode/CustomErrorCode.java
+++ b/api/src/main/java/clov3r/api/error/errorcode/CustomErrorCode.java
@@ -84,7 +84,8 @@ public enum CustomErrorCode implements ErrorCode {
 
   SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버와의 연결에 실패하였습니다."),
   DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 연결에 실패하였습니다."),
-  DATABASE_ERROR_QUERY(INTERNAL_SERVER_ERROR, "데이터베이스 쿼리 실행이 실패하였습니다."),;
+  DATABASE_ERROR_QUERY(INTERNAL_SERVER_ERROR, "데이터베이스 쿼리 실행이 실패하였습니다."),
+  KAKAO_ALARM_ERROR(INTERNAL_SERVER_ERROR, "카카오 알람 전송에 실패하였습니다."),;
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/api/src/main/java/clov3r/api/error/exception/GlobalExceptionHandlerV2.java
+++ b/api/src/main/java/clov3r/api/error/exception/GlobalExceptionHandlerV2.java
@@ -39,6 +39,13 @@ public class GlobalExceptionHandlerV2 extends ResponseEntityExceptionHandler {
     return handleExceptionInternal(errorCode, exception.getMessage());
   }
 
+  @ExceptionHandler(KakaoException.class)
+  public ResponseEntity<Object> handleKakaoException(final KakaoException exception) {
+    final ErrorCode errorCode = exception.getErrorCode();
+    log.error("AuthException : {}, errorCode : {}", exception, errorCode, exception);
+    return handleExceptionInternal(errorCode);
+  }
+
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException exception) {
     ErrorCode errorCode = CommonErrorCode.REQUEST_ERROR;

--- a/api/src/main/java/clov3r/api/error/exception/KakaoException.java
+++ b/api/src/main/java/clov3r/api/error/exception/KakaoException.java
@@ -1,0 +1,11 @@
+package clov3r.api.error.exception;
+
+import clov3r.api.error.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class KakaoException extends RuntimeException{
+  private final ErrorCode errorCode;
+}

--- a/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
@@ -297,4 +297,12 @@ public class GiftboxRepository {
                 .fetch();
     }
 
+    public List<Long> findParticipantsByGiftboxIdx(Long giftboxIdx) {
+        return queryFactory.select(giftboxUser.user.idx)
+                .from(giftboxUser)
+                .where(giftboxUser.giftbox.idx.eq(giftboxIdx),
+                        giftboxUser.invitationStatus.eq(InvitationStatus.ACCEPTED))
+                .fetch();
+    }
+
 }

--- a/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
@@ -3,6 +3,7 @@ package clov3r.api.repository;
 import static clov3r.api.domain.entity.QGiftbox.giftbox;
 import static clov3r.api.domain.entity.QGiftboxProduct.giftboxProduct;
 import static clov3r.api.domain.entity.QGiftboxUser.giftboxUser;
+import static clov3r.api.domain.entity.QInquiry.inquiry;
 import static clov3r.api.domain.entity.QProduct.product;
 import static clov3r.api.error.errorcode.CommonErrorCode.DATABASE_ERROR;
 import static clov3r.api.error.errorcode.CustomErrorCode.DATABASE_ERROR_NOT_FOUND;
@@ -305,4 +306,10 @@ public class GiftboxRepository {
                 .fetch();
     }
 
+    public Giftbox findByInquiryIdx(Long inquiryIdx) {
+        return queryFactory.select(giftbox)
+                .from(inquiry)
+                .where(inquiry.idx.eq(inquiryIdx))
+                .fetchOne();
+    }
 }

--- a/api/src/main/java/clov3r/api/repository/GiftboxUserRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxUserRepository.java
@@ -2,10 +2,12 @@ package clov3r.api.repository;
 
 import clov3r.api.domain.entity.GiftboxUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GiftboxUserRepository extends JpaRepository<GiftboxUser, Long> {
 
-
+  @Query("select gu.sender.idx from GiftboxUser gu where gu.idx = :invitationIdx")
+  Long findSenderByInvitationIdx(Long invitationIdx);
 }

--- a/api/src/main/java/clov3r/api/service/AuthService.java
+++ b/api/src/main/java/clov3r/api/service/AuthService.java
@@ -20,9 +20,8 @@ public class AuthService {
 
     private final RestTemplate restTemplate;
     private final UserRepository userRepository;
-
     /**
-     * 카카오 API 서버로부터 거져온 사용자 정보를 저장하는 메소드
+     * 카카오 API 서버로부터 가져온 사용자 정보를 저장하는 메소드
      * @param kakaoProfileDTO
      * @return
      */

--- a/api/src/main/java/clov3r/api/service/FriendService.java
+++ b/api/src/main/java/clov3r/api/service/FriendService.java
@@ -26,8 +26,7 @@ public class FriendService {
   private final UserRepository userRepository;
   private final FriendshipRepository friendshipRepository;
   private final NotificationService notificationService;
-  private final ApplicationEventPublisher applicationEventPublisher;
-  private final NotificationRepository notificationRepository;
+
 
   public FriendReq requestFriend(Long userIdx, Long friendIdx) {
 
@@ -40,9 +39,8 @@ public class FriendService {
     friendReqRepository.save(friendReq);
 
     // Send notification
-    Notification notification = notificationService.sendFriendRequestNotification(friendReq);
-    applicationEventPublisher.publishEvent(notification);
-    notificationRepository.save(notification);
+    notificationService.sendFriendRequestNotification(friendReq);
+
     return friendReq;
   }
 
@@ -53,9 +51,8 @@ public class FriendService {
     friendReq.updateBaseEntity();
 
     // Send notification
-    Notification notification = notificationService.sendFriendAcceptanceNotification(friendReq);
-    applicationEventPublisher.publishEvent(notification);
-    notificationRepository.save(notification);
+    notificationService.sendFriendAcceptanceNotification(friendReq);
+
   }
 
   @Transactional

--- a/api/src/main/java/clov3r/api/service/GiftboxService.java
+++ b/api/src/main/java/clov3r/api/service/GiftboxService.java
@@ -100,8 +100,7 @@ public class GiftboxService {
     giftboxRepository.acceptInvitationToGiftBox(userIdx, invitationIdx);
 
     // send notification
-    Notification notification = notificationService.sendGiftboxInvitationAcceptanceNotification(invitationIdx, giftboxUser.getGiftbox().getIdx(), userIdx);
-    applicationEventPublisher.publishEvent(notification);
-    notificationRepository.save(notification);
+    notificationService.sendGiftboxInvitationAcceptanceNotification(invitationIdx, giftboxUser.getGiftbox().getIdx(), userIdx);
+
   }
 }

--- a/api/src/main/java/clov3r/api/service/InquiryService.java
+++ b/api/src/main/java/clov3r/api/service/InquiryService.java
@@ -52,11 +52,8 @@ public class InquiryService {
     inquiryRepository.changeInquiryStatus(inquiryIdx, InquiryStatus.COMPLETE);
 
     // send notification
-    List<Notification> notificationList = notificationService.sendInquiryCompleteNotification(inquiryIdx);
-    for (Notification notification : notificationList) {
-      applicationEventPublisher.publishEvent(notification);
-      notificationRepository.save(notification);
-    }
+    notificationService.sendInquiryCompleteNotification(inquiryIdx);
+
   }
 
   @Transactional

--- a/api/src/main/java/clov3r/api/service/InquiryService.java
+++ b/api/src/main/java/clov3r/api/service/InquiryService.java
@@ -4,15 +4,18 @@ import clov3r.api.domain.data.status.InquiryStatus;
 import clov3r.api.domain.entity.Giftbox;
 import clov3r.api.domain.entity.GiftboxInquiryResult;
 import clov3r.api.domain.entity.Inquiry;
+import clov3r.api.domain.entity.Notification;
 import clov3r.api.domain.entity.Product;
 import clov3r.api.domain.request.InquiryRequest;
 import clov3r.api.repository.GiftboxRepository;
 import clov3r.api.repository.InquiryProductRepository;
 import clov3r.api.repository.InquiryRepository;
+import clov3r.api.repository.NotificationRepository;
 import clov3r.api.repository.ProductRepository;
 import clov3r.api.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +28,9 @@ public class InquiryService {
   private final InquiryRepository inquiryRepository;
   private final InquiryProductRepository inquiryProductRepository;
   private final UserRepository userRepository;
+  private final NotificationRepository notificationRepository;
+  private final NotificationService notificationService;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Transactional
   public Long createInquiry(InquiryRequest inquiryRequest, Long userIdx) {
@@ -43,9 +49,14 @@ public class InquiryService {
 
   @Transactional
   public void completeInquiry(Long inquiryIdx) {
-
     inquiryRepository.changeInquiryStatus(inquiryIdx, InquiryStatus.COMPLETE);
 
+    // send notification
+    List<Notification> notificationList = notificationService.sendInquiryCompleteNotification(inquiryIdx);
+    for (Notification notification : notificationList) {
+      applicationEventPublisher.publishEvent(notification);
+      notificationRepository.save(notification);
+    }
   }
 
   @Transactional

--- a/api/src/main/java/clov3r/api/service/NotificationService.java
+++ b/api/src/main/java/clov3r/api/service/NotificationService.java
@@ -122,4 +122,22 @@ public class NotificationService {
         .build();
     return notification;
   }
+
+  public List<Notification> sendInquiryCompleteNotification(Long inquiryIdx) {
+    Giftbox giftbox = giftboxRepository.findByInquiryIdx(inquiryIdx);
+    List<Long> participants = giftboxRepository.findParticipantsByGiftboxIdx(giftbox.getIdx());
+    // 선물바구니 참여자들에게 전송
+    return participants.stream().map(participantIdx -> {
+      return Notification.builder()
+          .receiver(userRepository.findByUserIdx(participantIdx))
+          .device(deviceRepository.findByUserId(participantIdx))
+          .title("선물바구니 ["+giftbox.getName()+"] 물어보기 완료")
+          .body("선물바구니 ["+giftbox.getName()+"] 에서 받고 싶은 선물 물어보기가 완료되었습니다.")
+          .actionType(ActionType.GIFT_ASK_COMPLETE)
+          .platformType("FCM")
+          .createdAt(LocalDateTime.now())
+          .notiStatus(NotiStatus.CREATED)
+          .build();
+    }).toList();
+  }
 }

--- a/api/src/main/java/clov3r/api/service/NotificationService.java
+++ b/api/src/main/java/clov3r/api/service/NotificationService.java
@@ -5,7 +5,7 @@ import static clov3r.api.error.errorcode.CustomErrorCode.KAKAO_ALARM_ERROR;
 import clov3r.api.domain.DTO.NotificationDTO;
 import clov3r.api.domain.DTO.kakao.KakaoAlarmResponseDTO;
 import clov3r.api.domain.data.ActionType;
-import clov3r.api.domain.data.kakao.SIGNUP_COMPLETE;
+import clov3r.api.domain.data.kakao.signupCompleteTemplate;
 import clov3r.api.domain.data.status.NotiStatus;
 import clov3r.api.domain.entity.Device;
 import clov3r.api.domain.entity.FriendReq;
@@ -209,7 +209,7 @@ public class NotificationService {
         .receiver(user)
         .build();
 
-    SIGNUP_COMPLETE signupComplete = new SIGNUP_COMPLETE();
+    signupCompleteTemplate signupComplete = new signupCompleteTemplate();
     KakaoAlarmResponseDTO kakaoAlarmResponseDTO = kakaoAlarmService.sendKakaoAlarmTalk(
         notification, signupComplete);
     if (!kakaoAlarmResponseDTO.getStatus().equals("OK")) {

--- a/api/src/main/java/clov3r/api/service/NotificationService.java
+++ b/api/src/main/java/clov3r/api/service/NotificationService.java
@@ -5,8 +5,11 @@ import clov3r.api.domain.data.ActionType;
 import clov3r.api.domain.data.status.NotiStatus;
 import clov3r.api.domain.entity.Device;
 import clov3r.api.domain.entity.FriendReq;
+import clov3r.api.domain.entity.Giftbox;
 import clov3r.api.domain.entity.Notification;
 import clov3r.api.repository.DeviceRepository;
+import clov3r.api.repository.GiftboxRepository;
+import clov3r.api.repository.GiftboxUserRepository;
 import clov3r.api.repository.NotificationRepository;
 import clov3r.api.repository.UserRepository;
 import java.time.LocalDateTime;
@@ -22,6 +25,8 @@ public class NotificationService {
   private final NotificationRepository notificationRepository;
   private final UserRepository userRepository;
   private final DeviceRepository deviceRepository;
+  private final GiftboxRepository giftboxRepository;
+  private final GiftboxUserRepository giftboxUserRepository;
 
   @Transactional
   public void saveDeviceToken(Long userIdx, String deviceToken, String deviceType) {
@@ -83,5 +88,38 @@ public class NotificationService {
     notification.setReadAt(LocalDateTime.now());
     notification.setNotiStatus(NotiStatus.READ);
     notificationRepository.save(notification);
+  }
+
+  public Notification sendGiftboxInvitationAcceptanceNotification(Long invitationIdx, Long giftboxIdx, Long userIdx) {
+//    List<Long> participants = giftboxRepository.findParticipantsByGiftboxIdx(giftboxIdx);
+    Giftbox giftbox = giftboxRepository.findById(giftboxIdx);
+    // 선물바구니 참여자들에게 전송
+//    for (Long participantIdx : participants) {
+//      Notification notification = Notification.builder()
+//          .receiver(userRepository.findByUserIdx(participantIdx))
+//          .sender(userRepository.findByUserIdx(userIdx))
+//          .device(deviceRepository.findByUserId(participantIdx))
+//          .title("선물바구니 ["+giftbox.getName()+"] 초대 수락")
+//          .body(userRepository.findByUserIdx(userIdx).getNickname() + "님이 ["+giftbox.getName()+"] 선물바구니 초대를 수락했습니다.")
+//          .actionType(ActionType.GIFTBOX_ACCEPTANCE)
+//          .platformType("FCM")
+//          .createdAt(LocalDateTime.now())
+//          .notiStatus(NotiStatus.CREATED)
+//          .build();
+//    }
+    // 선물바구니 초대장을 보낸 이에게 전송
+    Long invitationSenderIdx = giftboxUserRepository.findSenderByInvitationIdx(invitationIdx);
+    Notification notification = Notification.builder()
+        .receiver(userRepository.findByUserIdx(invitationSenderIdx))
+        .sender(userRepository.findByUserIdx(userIdx))
+        .device(deviceRepository.findByUserId(invitationSenderIdx))
+        .title("선물바구니 ["+giftbox.getName()+"] 초대 수락")
+        .body(userRepository.findByUserIdx(userIdx).getNickname() + "님이 ["+giftbox.getName()+"] 선물바구니 초대를 수락했습니다.")
+        .actionType(ActionType.GIFTBOX_ACCEPTANCE)
+        .platformType("FCM")
+        .createdAt(LocalDateTime.now())
+        .notiStatus(NotiStatus.CREATED)
+        .build();
+    return notification;
   }
 }

--- a/api/src/main/java/clov3r/api/service/NotificationService.java
+++ b/api/src/main/java/clov3r/api/service/NotificationService.java
@@ -1,20 +1,28 @@
 package clov3r.api.service;
 
+import static clov3r.api.error.errorcode.CustomErrorCode.KAKAO_ALARM_ERROR;
+
 import clov3r.api.domain.DTO.NotificationDTO;
+import clov3r.api.domain.DTO.kakao.KakaoAlarmResponseDTO;
 import clov3r.api.domain.data.ActionType;
+import clov3r.api.domain.data.kakao.SIGNUP_COMPLETE;
 import clov3r.api.domain.data.status.NotiStatus;
 import clov3r.api.domain.entity.Device;
 import clov3r.api.domain.entity.FriendReq;
 import clov3r.api.domain.entity.Giftbox;
 import clov3r.api.domain.entity.Notification;
+import clov3r.api.domain.entity.User;
+import clov3r.api.error.exception.KakaoException;
 import clov3r.api.repository.DeviceRepository;
 import clov3r.api.repository.GiftboxRepository;
 import clov3r.api.repository.GiftboxUserRepository;
 import clov3r.api.repository.NotificationRepository;
 import clov3r.api.repository.UserRepository;
+import clov3r.api.service.common.kakao.KakaoAlarmService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +35,15 @@ public class NotificationService {
   private final DeviceRepository deviceRepository;
   private final GiftboxRepository giftboxRepository;
   private final GiftboxUserRepository giftboxUserRepository;
+  private final KakaoAlarmService kakaoAlarmService;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
+  /**
+   * 디바이스 토큰 저장
+   * @param userIdx
+   * @param deviceToken
+   * @param deviceType
+   */
   @Transactional
   public void saveDeviceToken(Long userIdx, String deviceToken, String deviceType) {
     Device device = deviceRepository.findByUserId(userIdx);
@@ -44,8 +60,39 @@ public class NotificationService {
     }
   }
 
-  public Notification sendFriendRequestNotification(FriendReq friendReq) {
-    return Notification.builder()
+  /**
+   * 알림 리스트 조회
+   * @param userIdx
+   * @return
+   */
+  public List<NotificationDTO> getNotificationList(Long userIdx) {
+
+    List<Notification> notificationList= notificationRepository.findAllByUserId(userIdx);
+    return notificationList.stream()
+        .map(NotificationDTO::new)
+        .toList();
+  }
+
+  /**
+   * 알림 읽음 처리
+   * @param notificationIdx
+   */
+  @Transactional
+  public void readNotification(Long notificationIdx) {
+
+    Notification notification = notificationRepository.findById(notificationIdx).orElseThrow();
+    notification.setReadAt(LocalDateTime.now());
+    notification.setNotiStatus(NotiStatus.READ);
+    notificationRepository.save(notification);
+  }
+
+  /**
+   * 친구 요청 알림
+   * FCM 전송
+   * @param friendReq
+   */
+  public void sendFriendRequestNotification(FriendReq friendReq) {
+    Notification notification =  Notification.builder()
         .receiver(friendReq.getTo())
         .sender(friendReq.getFrom())
         .device(deviceRepository.findByUserId(friendReq.getTo().getIdx()))
@@ -56,8 +103,16 @@ public class NotificationService {
         .createdAt(LocalDateTime.now())
         .notiStatus(NotiStatus.CREATED)
         .build();
+    applicationEventPublisher.publishEvent(notification);
+    notificationRepository.save(notification);
   }
 
+  /**
+   * 친구 요청 수락 알림
+   * FCM 전송
+   * @param friendReq
+   * @return
+   */
   public Notification sendFriendAcceptanceNotification(FriendReq friendReq) {
     Notification notification = Notification.builder()
         .receiver(friendReq.getFrom())
@@ -69,27 +124,19 @@ public class NotificationService {
         .createdAt(LocalDateTime.now())
         .notiStatus(NotiStatus.CREATED)
         .build();
+    applicationEventPublisher.publishEvent(notification);
     notificationRepository.save(notification);
     return notification;
   }
 
-  public List<NotificationDTO> getNotificationList(Long userIdx) {
-
-    List<Notification> notificationList= notificationRepository.findAllByUserId(userIdx);
-    return notificationList.stream()
-        .map(NotificationDTO::new)
-        .toList();
-  }
-
-  @Transactional
-  public void readNotification(Long notificationIdx) {
-
-    Notification notification = notificationRepository.findById(notificationIdx).orElseThrow();
-    notification.setReadAt(LocalDateTime.now());
-    notification.setNotiStatus(NotiStatus.READ);
-    notificationRepository.save(notification);
-  }
-
+  /**
+   * 선물바구니 초대 수락 알림
+   * FCM 전송
+   * @param invitationIdx
+   * @param giftboxIdx
+   * @param userIdx
+   * @return
+   */
   public Notification sendGiftboxInvitationAcceptanceNotification(Long invitationIdx, Long giftboxIdx, Long userIdx) {
 //    List<Long> participants = giftboxRepository.findParticipantsByGiftboxIdx(giftboxIdx);
     Giftbox giftbox = giftboxRepository.findById(giftboxIdx);
@@ -120,14 +167,21 @@ public class NotificationService {
         .createdAt(LocalDateTime.now())
         .notiStatus(NotiStatus.CREATED)
         .build();
+    applicationEventPublisher.publishEvent(notification);
+    notificationRepository.save(notification);
     return notification;
   }
 
-  public List<Notification> sendInquiryCompleteNotification(Long inquiryIdx) {
+  /**
+   * 선물바구니 초대 수락 알림
+   * FCM 전송
+   * @param inquiryIdx
+   */
+  public void sendInquiryCompleteNotification(Long inquiryIdx) {
     Giftbox giftbox = giftboxRepository.findByInquiryIdx(inquiryIdx);
     List<Long> participants = giftboxRepository.findParticipantsByGiftboxIdx(giftbox.getIdx());
     // 선물바구니 참여자들에게 전송
-    return participants.stream().map(participantIdx -> {
+    List<Notification> notificationList =  participants.stream().map(participantIdx -> {
       return Notification.builder()
           .receiver(userRepository.findByUserIdx(participantIdx))
           .device(deviceRepository.findByUserId(participantIdx))
@@ -139,5 +193,29 @@ public class NotificationService {
           .notiStatus(NotiStatus.CREATED)
           .build();
     }).toList();
+    for (Notification notification : notificationList) {
+      applicationEventPublisher.publishEvent(notification);
+      notificationRepository.save(notification);
+    }
   }
+
+  /**
+   * 회원가입 완료 알림
+   * 카카오톡 알림 전송
+   * @param user
+   */
+  public void sendSignupCompleteNotification(User user) {
+    Notification notification =  Notification.builder()
+        .receiver(user)
+        .build();
+
+    SIGNUP_COMPLETE signupComplete = new SIGNUP_COMPLETE();
+    KakaoAlarmResponseDTO kakaoAlarmResponseDTO = kakaoAlarmService.sendKakaoAlarmTalk(
+        notification, signupComplete);
+    if (!kakaoAlarmResponseDTO.getStatus().equals("OK")) {
+      throw new KakaoException(KAKAO_ALARM_ERROR);
+    }
+    notificationRepository.save(notification);
+  }
+
 }

--- a/api/src/main/java/clov3r/api/service/UserService.java
+++ b/api/src/main/java/clov3r/api/service/UserService.java
@@ -2,19 +2,12 @@ package clov3r.api.service;
 
 import static clov3r.api.error.errorcode.CustomErrorCode.USER_NOT_FOUND;
 
-import clov3r.api.domain.DTO.KakaoProfileDTO;
-import clov3r.api.domain.DTO.kakao.KakaoAlarmResponseDTO;
-import clov3r.api.domain.DTO.kakao.KakaoButton;
-import clov3r.api.domain.data.kakao.SIGNUP_COMPLETE;
-import clov3r.api.domain.data.status.Status;
 import clov3r.api.domain.data.status.UserStatus;
-import clov3r.api.domain.entity.Notification;
 import clov3r.api.domain.entity.User;
 import clov3r.api.domain.request.SignupRequest;
 import clov3r.api.error.exception.BaseExceptionV2;
 import clov3r.api.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/api/src/main/java/clov3r/api/service/UserService.java
+++ b/api/src/main/java/clov3r/api/service/UserService.java
@@ -42,7 +42,7 @@ public class UserService {
         user.setBirthDate(signupRequest.getBirthDate());
         userRepository.save(user);
 
-        notificationService.sendSignupCompleteNotification(user);
+//        notificationService.sendSignupCompleteNotification(user);
         return user;
     }
 
@@ -51,10 +51,6 @@ public class UserService {
         User user = userRepository.findByUserIdx(userIdx);
         user.setStatus(UserStatus.INACTIVE);
         user.setDeletedAt(LocalDateTime.now());
-    }
-
-    public User loginByKakao(KakaoProfileDTO kakaoProfileDTO) {
-        return null;
     }
 
 }

--- a/api/src/main/java/clov3r/api/service/UserService.java
+++ b/api/src/main/java/clov3r/api/service/UserService.java
@@ -2,10 +2,19 @@ package clov3r.api.service;
 
 import static clov3r.api.error.errorcode.CustomErrorCode.USER_NOT_FOUND;
 
+import clov3r.api.domain.DTO.KakaoProfileDTO;
+import clov3r.api.domain.DTO.kakao.KakaoAlarmResponseDTO;
+import clov3r.api.domain.DTO.kakao.KakaoButton;
+import clov3r.api.domain.data.kakao.SIGNUP_COMPLETE;
+import clov3r.api.domain.data.status.Status;
+import clov3r.api.domain.data.status.UserStatus;
+import clov3r.api.domain.entity.Notification;
 import clov3r.api.domain.entity.User;
 import clov3r.api.domain.request.SignupRequest;
 import clov3r.api.error.exception.BaseExceptionV2;
 import clov3r.api.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     public User getUser(Long userIdx) {
         return userRepository.findByUserIdx(userIdx);
@@ -31,7 +41,20 @@ public class UserService {
         user.setGender(signupRequest.getGender());
         user.setBirthDate(signupRequest.getBirthDate());
         userRepository.save(user);
+
+        notificationService.sendSignupCompleteNotification(user);
         return user;
+    }
+
+    @Transactional
+    public void withdraw(Long userIdx) {
+        User user = userRepository.findByUserIdx(userIdx);
+        user.setStatus(UserStatus.INACTIVE);
+        user.setDeletedAt(LocalDateTime.now());
+    }
+
+    public User loginByKakao(KakaoProfileDTO kakaoProfileDTO) {
+        return null;
     }
 
 }

--- a/api/src/main/java/clov3r/api/service/common/kakao/KakaoAlarmService.java
+++ b/api/src/main/java/clov3r/api/service/common/kakao/KakaoAlarmService.java
@@ -1,0 +1,61 @@
+package clov3r.api.service.common.kakao;
+
+import clov3r.api.domain.DTO.kakao.KakaoAlarmBodyDTO;
+import clov3r.api.domain.DTO.kakao.KakaoAlarmResponseDTO;
+import clov3r.api.domain.DTO.kakao.KakaoButton;
+import clov3r.api.domain.data.kakao.KakaoAlarmTemplate;
+import clov3r.api.domain.entity.Notification;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAlarmService {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${kakao.talk-dream.auth-token}")
+  String authToken;
+  @Value("${kakao.talk-dream.server-name}")
+  String serverName;
+  @Value("${kakao.talk-dream.service-id}")
+  long serviceId;
+  @Value("${kakao.talk-dream.customer-inquiry}")
+  String customerInquiry;
+
+  public KakaoAlarmResponseDTO sendKakaoAlarmTalk(Notification notification, KakaoAlarmTemplate template) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("authToken", authToken);
+    headers.add("serverName", serverName);
+    headers.add("paymentType", "P");
+
+    // kakao api server end point URI
+    String uri = "https://talkapi.lgcns.com/request/kakao.json";
+    List<KakaoButton> buttonList = template.getButtons();
+    String message = template.makeMessage(notification, customerInquiry);
+    System.out.println("message = " + message);
+    KakaoAlarmBodyDTO body = KakaoAlarmBodyDTO.builder()
+        .service(serviceId)
+        .message(message)
+        .mobile(notification.getReceiver().getPhoneNumber())
+        .template(String.valueOf(template.getTemplateCode()))
+        .buttons(buttonList)
+        .build();
+    System.out.println("body.toString() = " + body.toString());
+    KakaoAlarmResponseDTO kakaoAlarmResponseDTO = restTemplate.exchange(
+            uri,
+            HttpMethod.POST,
+            new HttpEntity<>(body, headers),
+            KakaoAlarmResponseDTO.class)
+        .getBody();
+
+    return kakaoAlarmResponseDTO;
+  }
+
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -54,3 +54,10 @@ fcm:
     path: firebase-admin-sdk.json
   base-url: https://fcm.googleapis.com/v1/projects/oneit-gpt/messages:send
   auth-url: https://www.googleapis.com/auth/cloud-platform
+
+kakao:
+  talk-dream:
+    auth-token: ${KAKAO_ALARM_AUTH_TOKEN}
+    server-name: ${KAKAO_ALARM_SERVER_NAME}
+    service-id: ${KAKAO_ALARM_SERVICE_ID}
+    customer-inquiry: ${KAKAO_ALARM_CUSTOMER_INQUIRY}


### PR DESCRIPTION
# [ONE-802] 선물바구니 FCM 알림 기능
## 🔑 Key Change 
- 선물바구니 초대 수락 : 초대보낸사람에게 FCM 알림 전송
- 물어보기 완료 : 해당 선물바구니 참여자들에게 FCM 알림 전송

# [ONE-727] 회원가입 완료 카카오 알림톡 전송 로직
## 🔑 Key Change 
- 카카오 로그인 이후 자체 회원가입까지 완료시 카카오 알림톡 전송
- 회원가입 알림을 위한 템플릿 내용 기재
- 그 외 카카오 알림을 위한 secret 정보들(문의번호 포함)을 yml 파일에 환경변수로 제외함
- ❗️알림 전송을 위한 사용자 전화번호 수집을 하지 못하여 로직만 개발하고 주석 처리함

# [ONE-XX] 회원 탈퇴 API
## 🔑 Key Change 
- 회원 탈퇴시 사용자의 UserStatus 가 INACTIVE로 변경, deletedAt 탈퇴 시간으로 기재
- 재가입시 UserStatus가 ACTIVE로 변경되고, updatedAt이 재가입 시간으로 기재됨

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 
- remark 1


[ONE-802]: https://clov3r.atlassian.net/browse/ONE-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONE-727]: https://clov3r.atlassian.net/browse/ONE-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ