### PR TITLE
Feature/backend

### DIFF
--- a/api/src/main/java/clov3r/api/controller/GiftboxControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/GiftboxControllerV2.java
@@ -76,10 +76,6 @@ public class GiftboxControllerV2 {
     if (request.getDeadline().isBefore(LocalDateTime.now().toLocalDate())) {
       throw new BaseExceptionV2(DATE_BEFORE_NOW);
     }
-    if (!request.getAccessStatus().equals(AccessStatus.PUBLIC)
-        && !request.getAccessStatus().equals(AccessStatus.PRIVATE)) {
-      throw new BaseExceptionV2(INVALID_ACCESS_STATUS);
-    }
     // create Gift box
     Long giftboxIdx = giftboxService.createGiftbox(request, userIdx);
 
@@ -209,10 +205,6 @@ public class GiftboxControllerV2 {
     if (request.getDeadline().isBefore(LocalDateTime.now().toLocalDate())) {
       throw new BaseExceptionV2(DATE_BEFORE_NOW);
     }
-    if (!request.getAccessStatus().equals(AccessStatus.PUBLIC)
-        && !request.getAccessStatus().equals(AccessStatus.PRIVATE)) {
-      throw new BaseExceptionV2(INVALID_ACCESS_STATUS);
-    }
 
     // update giftbox
     giftboxService.updateGiftbox(giftboxIdx, request);
@@ -240,11 +232,9 @@ public class GiftboxControllerV2 {
     GiftboxDTO giftboxDTO = new GiftboxDTO(
         giftboxIdx,
         request.getName(),
-        request.getDescription(),
         request.getDeadline(),
         imageUrl,
         giftbox.getCreatedUserIdx(),
-        request.getAccessStatus(),
         participantsDTOList,
         giftbox.getCreatedAt());
     return ResponseEntity.ok(giftboxDTO);

--- a/api/src/main/java/clov3r/api/controller/GiftboxControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/GiftboxControllerV2.java
@@ -128,16 +128,7 @@ public class GiftboxControllerV2 {
         .toList();
 
     // make giftbox detail dto
-    GiftboxDTO giftboxDTO = new GiftboxDTO(
-        giftbox.getIdx(),
-        giftbox.getName(),
-        giftbox.getDescription(),
-        giftbox.getDeadline(),
-        giftbox.getImageUrl(),
-        giftbox.getCreatedUserIdx(),
-        giftbox.getAccessStatus(),
-        participantsDTOList
-    );
+    GiftboxDTO giftboxDTO = new GiftboxDTO(giftbox, participantsDTOList);
     return ResponseEntity.ok(giftboxDTO);
   }
 
@@ -167,16 +158,7 @@ public class GiftboxControllerV2 {
                   participant.getUserRole()
               ))
               .toList();
-          return new GiftboxDTO(
-              giftbox.getIdx(),
-              giftbox.getName(),
-              giftbox.getDescription(),
-              giftbox.getDeadline(),
-              giftbox.getImageUrl(),
-              giftbox.getCreatedUserIdx(),
-              giftbox.getAccessStatus(),
-              participantsDTOList
-          );
+          return new GiftboxDTO(giftbox, participantsDTOList);
         })
         .toList();
     return ResponseEntity.ok(giftboxDTOList);

--- a/api/src/main/java/clov3r/api/controller/GiftboxProductControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/GiftboxProductControllerV2.java
@@ -5,6 +5,7 @@ import static clov3r.api.error.errorcode.CustomErrorCode.*;
 
 import clov3r.api.config.security.Auth;
 import clov3r.api.domain.DTO.GiftboxProductDTO;
+import clov3r.api.domain.DTO.ProductSummaryDTO;
 import clov3r.api.domain.collection.GiftboxProductVoteId;
 import clov3r.api.domain.data.status.AccessStatus;
 import clov3r.api.domain.data.status.VoteStatus;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -103,21 +105,7 @@ public class GiftboxProductControllerV2 {
     }
 
     // get product list of the giftbox
-    List<GiftboxProduct> giftboxProductList = giftboxRepository.findGiftboxProductList(
-        giftboxIdx);
-
-    List<GiftboxProductDTO> giftboxProductDTOList = giftboxProductList.stream()
-        .map(giftboxProduct -> new GiftboxProductDTO(
-            giftboxProduct.getProduct().getIdx(),
-            giftboxProduct.getProduct().getName(),
-            giftboxProduct.getProduct().getDescription(),
-            giftboxProduct.getProduct().getOriginalPrice(),
-            giftboxProduct.getProduct().getThumbnailUrl(),
-            giftboxProduct.getLikeCount(),
-            giftboxProductService.getVoteStatusOfUser(userIdx, giftboxIdx,
-                giftboxProduct.getProduct().getIdx()),
-            giftboxProduct.getPurchaseStatus()
-        )).toList();
+    List<GiftboxProductDTO> giftboxProductDTOList = giftboxService.findGiftboxProductList(giftboxIdx, userIdx);
 
     return ResponseEntity.ok(giftboxProductDTOList);
   }
@@ -246,6 +234,36 @@ public class GiftboxProductControllerV2 {
     // purchase product
     giftboxProductService.purchaseProduct(giftboxIdx, productIdx);
     return ResponseEntity.ok("제품을 구매했습니다.");
+  }
+
+  @Tag(name = "선물바구니 상품 API", description = "선물바구니 API 목록")
+  @Operation(summary = "선물바구니 제품 검색", description = "선물바구니 내 제품 검색")
+  @GetMapping("/api/v2/giftbox/{giftboxIdx}/products/search")
+  public ResponseEntity<List<ProductSummaryDTO>> searchProductInGiftbox(
+      @PathVariable("giftboxIdx") Long giftboxIdx,
+      @RequestParam String searchKeyword,
+      @Parameter(hidden = true) @Auth(required = false) Long userIdx
+  ) {
+    // request validation
+    if (giftboxIdx == null || searchKeyword == null) {
+      throw new BaseExceptionV2(REQUEST_ERROR);
+    }
+    if (searchKeyword.length() < 2) {
+      throw new BaseExceptionV2(SEARCH_KEYWORD_ERROR);
+    }
+    if (!giftboxRepository.existsById(giftboxIdx)) {
+      throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
+    }
+    if (!userRepository.existsByUserIdx(userIdx)) {
+      throw new BaseExceptionV2(USER_NOT_FOUND);
+    }
+    if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
+      throw new BaseExceptionV2(NOT_PARTICIPANT_OF_GIFTBOX);  // 해당 선물 바구니의 참여자만 검색 가능함
+    }
+
+    // search product in giftbox
+    List<ProductSummaryDTO> productSummaryDTOList = giftboxService.searchProductInGiftbox(searchKeyword, giftboxIdx);
+    return ResponseEntity.ok(productSummaryDTOList);
   }
 
 }

--- a/api/src/main/java/clov3r/api/controller/GiftboxProductControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/GiftboxProductControllerV2.java
@@ -86,7 +86,7 @@ public class GiftboxProductControllerV2 {
   @GetMapping("/api/v2/giftbox/{giftboxIdx}/products")
   public ResponseEntity<List<GiftboxProductDTO>> getProductOfGiftbox(
       @PathVariable("giftboxIdx") Long giftboxIdx,
-      @Parameter(hidden = true) @Auth(required = false) Long userIdx
+      @Parameter(hidden = true) @Auth Long userIdx
   ) {
     // request validation
     if (giftboxIdx == null) {
@@ -97,11 +97,8 @@ public class GiftboxProductControllerV2 {
     if (giftbox == null) {
       throw new BaseExceptionV2(GIFTBOX_NOT_FOUND);
     }
-    if (giftbox.getAccessStatus().equals(AccessStatus.PRIVATE)) {
-      if (userIdx == null || !giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
-        // 선물 바구니가 PRIVATE 일 경우, 해당 선물 바구니의 참여자만 조회 가능함
-        throw new BaseExceptionV2(NOT_PARTICIPANT_OF_GIFTBOX);
-      }
+    if (!giftboxRepository.isParticipantOfGiftbox(userIdx, giftboxIdx)) {
+      throw new BaseExceptionV2(NOT_PARTICIPANT_OF_GIFTBOX); // 해당 선물 바구니의 참여자만 조회 가능함
     }
 
     // get product list of the giftbox

--- a/api/src/main/java/clov3r/api/domain/DTO/CommentDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/CommentDTO.java
@@ -16,6 +16,7 @@ public class CommentDTO {
   private Long giftboxProductIdx;
   private Long writerIdx;
   private String writerNickName;
+  private String writerProfileImg;
   private String content;
   private LocalDateTime createdAt;
 
@@ -24,6 +25,7 @@ public class CommentDTO {
     this.giftboxProductIdx = comment.getGiftboxProductIdx();
     this.writerIdx = comment.getWriter().getIdx();
     this.writerNickName = comment.getWriter().getNickname();
+    this.writerProfileImg = comment.getWriter().getProfileImg();
     this.content = comment.getContent();
     this.createdAt = comment.getCreatedAt();
   }

--- a/api/src/main/java/clov3r/api/domain/DTO/GiftboxDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/GiftboxDTO.java
@@ -21,14 +21,14 @@ public class GiftboxDTO {
     private List<ParticipantsDTO> participants;
     private LocalDateTime createdAt;
 
-    public GiftboxDTO(Long idx, String name, String description, LocalDate deadline, String imageUrl, Long createdUserIdx, AccessStatus accessStatus, List<ParticipantsDTO> participants, LocalDateTime createdAt) {
+    public GiftboxDTO(Long idx, String name, LocalDate deadline, String imageUrl, Long createdUserIdx, List<ParticipantsDTO> participants, LocalDateTime createdAt) {
         this.idx = idx;
         this.name = name;
-        this.description = description;
+//        this.description = description;
         this.deadline = deadline;
         this.imageUrl = imageUrl;
         this.createdUserIdx = createdUserIdx;
-        this.accessStatus = accessStatus;
+//        this.accessStatus = accessStatus;
         this.participants = participants;
         this.createdAt = createdAt;
     }
@@ -36,11 +36,9 @@ public class GiftboxDTO {
     public GiftboxDTO(Giftbox giftbox, List<ParticipantsDTO> participants) {
         this.idx = giftbox.getIdx();
         this.name = giftbox.getName();
-        this.description = giftbox.getDescription();
         this.deadline = giftbox.getDeadline();
         this.imageUrl = giftbox.getImageUrl();
         this.createdUserIdx = giftbox.getCreatedUserIdx();
-        this.accessStatus = giftbox.getAccessStatus();
         this.participants = participants;
         this.createdAt = giftbox.getCreatedAt();
     }

--- a/api/src/main/java/clov3r/api/domain/DTO/GiftboxDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/GiftboxDTO.java
@@ -20,6 +20,7 @@ public class GiftboxDTO {
     private AccessStatus accessStatus;
     private List<ParticipantsDTO> participants;
     private LocalDateTime createdAt;
+    private int dDay;
 
     public GiftboxDTO(Long idx, String name, LocalDate deadline, String imageUrl, Long createdUserIdx, List<ParticipantsDTO> participants, LocalDateTime createdAt) {
         this.idx = idx;
@@ -31,6 +32,7 @@ public class GiftboxDTO {
 //        this.accessStatus = accessStatus;
         this.participants = participants;
         this.createdAt = createdAt;
+        this.dDay = getDDay();
     }
 
     public GiftboxDTO(Giftbox giftbox, List<ParticipantsDTO> participants) {
@@ -41,6 +43,11 @@ public class GiftboxDTO {
         this.createdUserIdx = giftbox.getCreatedUserIdx();
         this.participants = participants;
         this.createdAt = giftbox.getCreatedAt();
+        this.dDay = getDDay();
+    }
+
+    public int getDDay() {
+        return (int) LocalDate.now().until(deadline, java.time.temporal.ChronoUnit.DAYS);
     }
 
 }

--- a/api/src/main/java/clov3r/api/domain/DTO/GiftboxDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/GiftboxDTO.java
@@ -3,6 +3,7 @@ package clov3r.api.domain.DTO;
 import clov3r.api.domain.data.status.AccessStatus;
 import clov3r.api.domain.entity.Giftbox;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,8 +19,9 @@ public class GiftboxDTO {
     private Long createdUserIdx;
     private AccessStatus accessStatus;
     private List<ParticipantsDTO> participants;
+    private LocalDateTime createdAt;
 
-    public GiftboxDTO(Long idx, String name, String description, LocalDate deadline, String imageUrl, Long createdUserIdx, AccessStatus accessStatus, List<ParticipantsDTO> participants) {
+    public GiftboxDTO(Long idx, String name, String description, LocalDate deadline, String imageUrl, Long createdUserIdx, AccessStatus accessStatus, List<ParticipantsDTO> participants, LocalDateTime createdAt) {
         this.idx = idx;
         this.name = name;
         this.description = description;
@@ -28,9 +30,10 @@ public class GiftboxDTO {
         this.createdUserIdx = createdUserIdx;
         this.accessStatus = accessStatus;
         this.participants = participants;
+        this.createdAt = createdAt;
     }
 
-    public GiftboxDTO(Giftbox giftbox) {
+    public GiftboxDTO(Giftbox giftbox, List<ParticipantsDTO> participants) {
         this.idx = giftbox.getIdx();
         this.name = giftbox.getName();
         this.description = giftbox.getDescription();
@@ -38,6 +41,8 @@ public class GiftboxDTO {
         this.imageUrl = giftbox.getImageUrl();
         this.createdUserIdx = giftbox.getCreatedUserIdx();
         this.accessStatus = giftbox.getAccessStatus();
+        this.participants = participants;
+        this.createdAt = giftbox.getCreatedAt();
     }
 
 }

--- a/api/src/main/java/clov3r/api/domain/DTO/GiftboxProductDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/GiftboxProductDTO.java
@@ -1,14 +1,19 @@
 package clov3r.api.domain.DTO;
 
+import clov3r.api.domain.data.status.ProductStatus;
 import clov3r.api.domain.data.status.PurchaseStatus;
 import clov3r.api.domain.data.status.VoteStatus;
+import clov3r.api.domain.entity.GiftboxProduct;
+import clov3r.api.domain.entity.Product;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Data
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class GiftboxProductDTO {
@@ -22,5 +27,27 @@ public class GiftboxProductDTO {
   private int likeCount;
   private VoteStatus voteStatus;
   private PurchaseStatus purchaseStatus;
+  private Long emojiIdx;
+  private ProductStatus productStatus;
+
+  public GiftboxProductDTO(GiftboxProduct giftboxProduct, VoteStatus voteStatus) {
+    this.idx = giftboxProduct.getProduct().getIdx();
+    this.name = giftboxProduct.getProduct().getName();
+    this.description = giftboxProduct.getProduct().getDescription();
+    this.originalPrice = giftboxProduct.getProduct().getOriginalPrice();
+    this.thumbnailUrl = giftboxProduct.getProduct().getThumbnailUrl();
+    this.likeCount = giftboxProduct.getLikeCount();
+    this.voteStatus = voteStatus;
+    this.purchaseStatus = giftboxProduct.getPurchaseStatus();
+    this.productStatus = giftboxProduct.getProduct().getStatus();
+  }
+
+  public GiftboxProductDTO(Product product) {
+    this.idx = product.getIdx();
+    this.name = product.getName();
+    this.description = product.getDescription();
+    this.originalPrice = product.getOriginalPrice();
+    this.thumbnailUrl = product.getThumbnailUrl();
+  }
 
 }

--- a/api/src/main/java/clov3r/api/domain/entity/Giftbox.java
+++ b/api/src/main/java/clov3r/api/domain/entity/Giftbox.java
@@ -66,5 +66,6 @@ public class Giftbox extends BaseEntity {
         this.deadline = deadline;
         this.createdUserIdx = userIdx;
         this.status = status;
+        this.createBaseEntity();
     }
 }

--- a/api/src/main/java/clov3r/api/domain/entity/Giftbox.java
+++ b/api/src/main/java/clov3r/api/domain/entity/Giftbox.java
@@ -60,4 +60,11 @@ public class Giftbox extends BaseEntity {
     public Giftbox() {
 
     }
+
+    public Giftbox(String name, LocalDate deadline, Long userIdx, Status status) {
+        this.name = name;
+        this.deadline = deadline;
+        this.createdUserIdx = userIdx;
+        this.status = status;
+    }
 }

--- a/api/src/main/java/clov3r/api/domain/request/PostGiftboxRequest.java
+++ b/api/src/main/java/clov3r/api/domain/request/PostGiftboxRequest.java
@@ -9,7 +9,5 @@ import lombok.Getter;
 @Getter
 public class PostGiftboxRequest {
     private String name;
-    private String description;
     private LocalDate deadline;
-    private AccessStatus accessStatus;
 }

--- a/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
@@ -312,4 +312,18 @@ public class GiftboxRepository {
                 .where(inquiry.idx.eq(inquiryIdx))
                 .fetchOne();
     }
+
+    public List<Product> searchProductInGiftbox(String searchKeyword, Long giftboxIdx) {
+        // giftboxIdx로 status가 ACTIVE인 product 중 검색어가 포함된 product 조회
+        return queryFactory.select(product)
+                .from(giftbox)
+                .join(giftbox.products, giftboxProduct)
+                .where(giftboxProduct.giftbox.idx.eq(giftboxIdx),
+                        product.idx.eq(giftboxProduct.product.idx),
+                        product.status.eq(ProductStatus.ACTIVE),
+                        giftboxProduct.status.eq(Status.ACTIVE),
+                        product.name.contains(searchKeyword))
+                .fetch();
+    }
+
 }

--- a/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
@@ -158,6 +158,7 @@ public class GiftboxRepository {
                 .where(giftboxUser.user.idx.eq(userIdx),
                         giftboxUser.invitationStatus.eq(InvitationStatus.ACCEPTED),
                         giftbox.status.eq(Status.ACTIVE))
+                .orderBy(giftbox.createdAt.desc())
                 .fetch();
     }
 

--- a/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
@@ -77,14 +77,11 @@ public class GiftboxRepository {
                 .execute();
     }
 
-    @Transactional
     public void updateGiftbox(Long giftboxIdx, PostGiftboxRequest request) {
         // giftbox의 정보를 수정
         queryFactory.update(giftbox)
                 .set(giftbox.name, request.getName())
-                .set(giftbox.description, request.getDescription())
                 .set(giftbox.deadline, request.getDeadline())
-                .set(giftbox.accessStatus, request.getAccessStatus())
                 .set(giftbox.updatedAt, LocalDateTime.now())
                 .where(giftbox.idx.eq(giftboxIdx),
                         giftbox.status.eq(Status.ACTIVE))

--- a/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
+++ b/api/src/main/java/clov3r/api/repository/GiftboxRepository.java
@@ -158,7 +158,8 @@ public class GiftboxRepository {
                 .where(giftboxUser.user.idx.eq(userIdx),
                         giftboxUser.invitationStatus.eq(InvitationStatus.ACCEPTED),
                         giftbox.status.eq(Status.ACTIVE))
-                .orderBy(giftbox.createdAt.desc())
+//                .orderBy(giftbox.createdAt.desc())
+                .orderBy(giftbox.deadline.asc())
                 .fetch();
     }
 

--- a/api/src/main/java/clov3r/api/repository/ProductRepository.java
+++ b/api/src/main/java/clov3r/api/repository/ProductRepository.java
@@ -239,18 +239,16 @@ public class ProductRepository {
      * @param pageSize
      * @return
      */
-    public List<ProductSummaryDTO> findProductListPagination(Long productIdx, int pageSize) {
+    public List<Product> findProductListPagination(Long productIdx, int pageSize) {
         return queryFactory
-                .select(
-                    Projections.fields(ProductSummaryDTO.class,
-                        product.idx,
-                        product.name,
-                        product.originalPrice,
-                        product.currentPrice,
-                        product.discountRate,
-                        product.thumbnailUrl))
+                .select(product)
                 .from(product)
                 .where(ltProduct(productIdx))
+                .where(
+                    product.name.isNotNull(),
+                    product.originalPrice.isNotNull(),
+                    product.thumbnailUrl.isNotNull()
+                )
                 .orderBy(product.idx.desc())
                 .limit(pageSize)
                 .fetch();
@@ -268,8 +266,15 @@ public class ProductRepository {
         return product.idx.lt(productIdx);
     }
     public List<Product> findAll() {
-        return em.createQuery("select p from Product p", Product.class)
-                .getResultList();
+        List<Product> products = queryFactory.selectFrom(product)
+            .where(
+                product.name.isNotNull(),
+                product.originalPrice.isNotNull(),
+                product.thumbnailUrl.isNotNull()
+            )
+            .fetch();
+        return products;
+
     }
 
     public boolean existsProduct(Long productIdx) {

--- a/api/src/main/java/clov3r/api/service/GiftboxProductService.java
+++ b/api/src/main/java/clov3r/api/service/GiftboxProductService.java
@@ -60,8 +60,8 @@ public class GiftboxProductService {
   }
 
 
-  public VoteStatus getVoteStatusOfUser(Long userIdx, Long giftboxIdx, Long idx) {
-    VoteStatus voteStatus = giftboxProductVoteRepository.getVoteStatusOfUser(userIdx, giftboxIdx, idx);
+  public VoteStatus getVoteStatusOfUser(Long userIdx, Long giftboxIdx, Long productIdx) {
+    VoteStatus voteStatus = giftboxProductVoteRepository.getVoteStatusOfUser(userIdx, giftboxIdx, productIdx);
     if (voteStatus == null || voteStatus == VoteStatus.NONE) {
       return VoteStatus.NONE;
     }

--- a/api/src/main/java/clov3r/api/service/GiftboxService.java
+++ b/api/src/main/java/clov3r/api/service/GiftboxService.java
@@ -4,19 +4,26 @@ import static clov3r.api.error.errorcode.CommonErrorCode.DATABASE_ERROR;
 import static clov3r.api.error.errorcode.CustomErrorCode.FAIL_TO_UPDATE_GIFTBOX;
 import static clov3r.api.error.errorcode.CustomErrorCode.FAIL_TO_UPDATE_GIFTBOX_IMAGE_URL;
 
+import clov3r.api.domain.DTO.GiftboxProductDTO;
+import clov3r.api.domain.DTO.ProductSummaryDTO;
 import clov3r.api.domain.data.GiftboxUserRole;
 import clov3r.api.domain.data.status.InvitationStatus;
 import clov3r.api.domain.data.status.Status;
 import clov3r.api.domain.entity.Giftbox;
+import clov3r.api.domain.entity.GiftboxProduct;
 import clov3r.api.domain.entity.GiftboxUser;
+import clov3r.api.domain.entity.InquiryProduct;
 import clov3r.api.domain.entity.Notification;
+import clov3r.api.domain.entity.Product;
 import clov3r.api.domain.request.PostGiftboxRequest;
 import clov3r.api.error.exception.BaseExceptionV2;
 import clov3r.api.repository.GiftboxRepository;
 import clov3r.api.repository.GiftboxUserRepository;
+import clov3r.api.repository.InquiryRepository;
 import clov3r.api.repository.NotificationRepository;
 import clov3r.api.repository.ProductRepository;
 import clov3r.api.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -33,6 +40,8 @@ public class GiftboxService {
   private final NotificationRepository notificationRepository;
   private final NotificationService notificationService;
   private final ApplicationEventPublisher applicationEventPublisher;
+  private final GiftboxProductService giftboxProductService;
+  private final InquiryRepository inquiryRepository;
 
   public Long createGiftbox(PostGiftboxRequest request, Long userIdx) {
 
@@ -102,5 +111,23 @@ public class GiftboxService {
     // send notification
     notificationService.sendGiftboxInvitationAcceptanceNotification(invitationIdx, giftboxUser.getGiftbox().getIdx(), userIdx);
 
+  }
+
+  public List<ProductSummaryDTO> searchProductInGiftbox(String searchKeyword, Long giftboxIdx) {
+    List<Product> products = giftboxRepository.searchProductInGiftbox(searchKeyword, giftboxIdx);
+    return products.stream()
+        .map(ProductSummaryDTO::new).toList();
+  }
+
+  public List<GiftboxProductDTO> findGiftboxProductList(Long giftboxIdx, Long userIdx) {
+    List<GiftboxProduct> giftboxProductList = giftboxRepository.findGiftboxProductList(giftboxIdx);
+    List<InquiryProduct> inquiryProductList = inquiryRepository.findInquiryProductList(giftboxIdx);
+    List<GiftboxProductDTO> giftboxProductDTOList = giftboxProductList.stream()
+        .map(GiftboxProductDTO::new).toList();
+
+    for (InquiryProduct inquiryProduct : inquiryProductList) {
+
+    }
+    return giftboxProductDTOList;
   }
 }

--- a/api/src/main/java/clov3r/api/service/GiftboxService.java
+++ b/api/src/main/java/clov3r/api/service/GiftboxService.java
@@ -121,13 +121,16 @@ public class GiftboxService {
 
   public List<GiftboxProductDTO> findGiftboxProductList(Long giftboxIdx, Long userIdx) {
     List<GiftboxProduct> giftboxProductList = giftboxRepository.findGiftboxProductList(giftboxIdx);
-    List<InquiryProduct> inquiryProductList = inquiryRepository.findInquiryProductList(giftboxIdx);
+//    List<InquiryProduct> inquiryProductList = inquiryRepository.findInquiryProductList(giftboxIdx);
     List<GiftboxProductDTO> giftboxProductDTOList = giftboxProductList.stream()
-        .map(GiftboxProductDTO::new).toList();
-
-    for (InquiryProduct inquiryProduct : inquiryProductList) {
-
-    }
+        .map(giftboxProduct ->
+            new GiftboxProductDTO(
+                giftboxProduct,
+                giftboxProductService.getVoteStatusOfUser(
+                    userIdx,
+                    giftboxProduct.getGiftbox().getIdx(),
+                    giftboxProduct.getProduct().getIdx())
+            )).toList();
     return giftboxProductDTOList;
   }
 }

--- a/api/src/main/java/clov3r/api/service/GiftboxService.java
+++ b/api/src/main/java/clov3r/api/service/GiftboxService.java
@@ -23,6 +23,7 @@ import clov3r.api.repository.InquiryRepository;
 import clov3r.api.repository.NotificationRepository;
 import clov3r.api.repository.ProductRepository;
 import clov3r.api.repository.UserRepository;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -47,10 +48,8 @@ public class GiftboxService {
 
     Giftbox newGiftbox = new Giftbox(
         request.getName(),
-        request.getDescription(),
         request.getDeadline(),
         userIdx,
-        request.getAccessStatus(),
         Status.ACTIVE
     );
     Giftbox saveGiftbox = giftboxRepository.save(newGiftbox);
@@ -74,6 +73,7 @@ public class GiftboxService {
     }
   }
 
+  @Transactional
   public void updateGiftbox(Long giftboxIdx, PostGiftboxRequest request) {
     try {
       giftboxRepository.updateGiftbox(giftboxIdx, request);

--- a/api/src/main/java/clov3r/api/service/NotificationService.java
+++ b/api/src/main/java/clov3r/api/service/NotificationService.java
@@ -117,7 +117,7 @@ public class NotificationService {
     Notification notification = Notification.builder()
         .receiver(friendReq.getFrom())
         .sender(friendReq.getTo())
-        .device(deviceRepository.findByUserId(friendReq.getTo().getIdx()))
+        .device(deviceRepository.findByUserId(friendReq.getFrom().getIdx()))
         .title("친구 요청 수락")
         .body(friendReq.getTo().getNickname() + "님이 친구 요청을 수락했습니다.")
         .actionType(ActionType.FRIEND_ACCEPTANCE)

--- a/api/src/main/java/clov3r/api/service/ProductService.java
+++ b/api/src/main/java/clov3r/api/service/ProductService.java
@@ -61,7 +61,9 @@ public class ProductService {
     }
 
     public List<ProductSummaryDTO> getProductListPagination(Long lastProductIdx, int pageSize) {
-        return productRepository.findProductListPagination(lastProductIdx, pageSize);
+      List<Product> products =  productRepository.findProductListPagination(lastProductIdx, pageSize);
+        return products.stream()
+                .map(ProductSummaryDTO::new).toList();
     }
 
   public List<ProductSummaryDTO> searchProduct(String searchKeyword) {


### PR DESCRIPTION
# [ONE-XX] 백엔드 추가 수정 및 요청사항
## 🔑 Key Change 
- 선물바구니 내 제품 검색 기능
- 친구 요청 수락 알림 보낸이와 받는이 변경
- 선물바구니 정보 응답값에 생성일 추가
- 상품 댓글 정보 응답값에 작성자 프로필 이미지 url 추가
- 상품 조회시 name, originalPrice, ThumbnailUrl 중 하나라도 null 이라면 조회되지 않게 필터링
- 선물바구니 수정한 뒤 수정한 선물바구니 정보 리턴
- 선물바구니 생성 및 수정시 필요없는 요청값 제외
- 선물바구니 리스트 마감임박 데드라인 순으로 정렬
- 선물바구니 d-day 계산해서 선물바구니 정보 응답값에 추가
- 선물바구니 상품 조회시 로그인 유저이면서 참여자만 가능하도록 수정

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 
- 선물 바구니 내 상품 조회시 물어보기/좋아요 정보 추가는 아직 진행중입니다
- 선물바구니 리스트 정렬은 일단 마감임박순으로 했습니다
