### PR TITLE
Feature/product like

### DIFF
--- a/api/src/main/java/clov3r/api/controller/CollectionControllerV2.java
+++ b/api/src/main/java/clov3r/api/controller/CollectionControllerV2.java
@@ -1,5 +1,6 @@
 package clov3r.api.controller;
 
+import clov3r.api.config.security.Auth;
 import clov3r.api.domain.DTO.CollectionDTO;
 import clov3r.api.domain.DTO.CollectionProductDTO;
 import clov3r.api.domain.DTO.ProductDTO;
@@ -8,6 +9,7 @@ import clov3r.api.domain.entity.Product;
 import clov3r.api.repository.CollectionRepository;
 import clov3r.api.repository.KeywordRepository;
 import clov3r.api.service.CollectionService;
+import clov3r.api.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +26,7 @@ public class CollectionControllerV2 {
   private final CollectionService collectionService;
   private final CollectionRepository collectionRepository;
   private final KeywordRepository keywordRepository;
+  private final ProductService productService;
 
   @Tag(name = "컬렉션 API", description = "컬렉션(둘러보기) API")
   @Operation(summary = "컬렉션 리스트 조회", description = "컬렉션 리스트를 조회합니다.")
@@ -43,7 +46,8 @@ public class CollectionControllerV2 {
   @Operation(summary = "컬렉션 상세 조회", description = "컬렉션 정보와 컬렉션에 속한 상품 리스트를 조회합니다.")
   @GetMapping("api/v2/collections/{collectionIdx}")
   public ResponseEntity<CollectionProductDTO> getProductList(
-      @Parameter(description = "컬렉션 idx") @PathVariable Long collectionIdx
+      @Parameter(description = "컬렉션 idx") @PathVariable Long collectionIdx,
+      @Parameter(hidden = true) @Auth(required = false) Long userIdx
   ) {
     Collection collection = collectionRepository.getCollection(collectionIdx);
     List<Product> productList = collectionRepository.getProductList(collectionIdx);
@@ -54,7 +58,8 @@ public class CollectionControllerV2 {
         collection.getThumbnailUrl(),
         productList.stream().map(product -> new ProductDTO(
             product,
-            keywordRepository.findKeywordByProductIdx(product.getIdx())
+            keywordRepository.findKeywordByProductIdx(product.getIdx()),
+            productService.getLikeStatus(product.getIdx(), userIdx)
         )).toList()
     );
     return ResponseEntity.ok(collectionProductDTO);

--- a/api/src/main/java/clov3r/api/controller/InquiryController.java
+++ b/api/src/main/java/clov3r/api/controller/InquiryController.java
@@ -27,6 +27,7 @@ import clov3r.api.repository.InquiryRepository;
 import clov3r.api.repository.ProductRepository;
 import clov3r.api.service.InquiryProductService;
 import clov3r.api.service.InquiryService;
+import clov3r.api.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,6 +50,7 @@ public class InquiryController {
   private final InquiryProductService inquiryProductService;
   private final InquiryProductRepository inquiryProductRepository;
   private final ProductRepository productRepository;
+  private final ProductService productService;
 
   @Tag(name = "물어보기 API", description = "물어보기 API 목록")
   @Operation(summary = "물어보기 생성", description = "물어보기를 생성합니다.")
@@ -105,7 +107,12 @@ public class InquiryController {
     }
     List<Product> productList = inquiryProductRepository.findProductListByInquiry(inquiry);
     InquiryDTO inquiryDTO = new InquiryDTO(inquiry,
-        productList.stream().map(ProductSummaryDTO::new).toList());
+        productList.stream().map(
+            product -> new ProductSummaryDTO(
+                product,
+                productService.getLikeStatus(product.getIdx(), userIdx)
+            )
+        ).toList());
 
     return ResponseEntity.ok(inquiryDTO);
   }

--- a/api/src/main/java/clov3r/api/domain/DTO/ProductDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/ProductDTO.java
@@ -1,6 +1,7 @@
 package clov3r.api.domain.DTO;
 
 import clov3r.api.domain.data.Gender;
+import clov3r.api.domain.data.status.LikeStatus;
 import clov3r.api.domain.data.status.ProductStatus;
 import clov3r.api.domain.entity.Category;
 import clov3r.api.domain.entity.Keyword;
@@ -29,8 +30,9 @@ public class ProductDTO {
     private Gender gender;
     private ProductStatus status;
     private int likeCount;
+    private LikeStatus likeStatus;
 
-    public ProductDTO(Product product, List<Keyword> keywords) {
+    public ProductDTO(Product product, List<Keyword> keywords, LikeStatus likeStatus) {
         this.idx = product.getIdx();
         this.name = product.getName();
         this.description = product.getDescription();
@@ -45,5 +47,6 @@ public class ProductDTO {
         this.gender = product.getGender();
         this.status = product.getStatus();
         this.likeCount = product.getLikeCount();
+        this.likeStatus = likeStatus;
     }
 }

--- a/api/src/main/java/clov3r/api/domain/DTO/ProductDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/ProductDTO.java
@@ -28,6 +28,7 @@ public class ProductDTO {
     private List<Keyword> keywords  = new ArrayList<>();
     private Gender gender;
     private ProductStatus status;
+    private int likeCount;
 
     public ProductDTO(Product product, List<Keyword> keywords) {
         this.idx = product.getIdx();
@@ -43,5 +44,6 @@ public class ProductDTO {
         this.keywords.addAll(keywords);
         this.gender = product.getGender();
         this.status = product.getStatus();
+        this.likeCount = product.getLikeCount();
     }
 }

--- a/api/src/main/java/clov3r/api/domain/DTO/ProductDetailDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/ProductDetailDTO.java
@@ -1,5 +1,6 @@
 package clov3r.api.domain.DTO;
 
+import clov3r.api.domain.data.status.LikeStatus;
 import clov3r.api.domain.data.status.ProductStatus;
 import clov3r.api.domain.entity.Category;
 import clov3r.api.domain.entity.Keyword;
@@ -29,9 +30,10 @@ public class ProductDetailDTO {
     private List<String> keywords = new ArrayList<>();
     private ProductStatus status;
     private int likeCount;
+    private LikeStatus likeStatus;
 
     // 상세 조회시 사용
-    public ProductDetailDTO(Product product, List<Keyword> keywords, Category category) {
+    public ProductDetailDTO(Product product, List<Keyword> keywords, Category category, LikeStatus likeStatus) {
         this.idx = product.getIdx();
         this.name = product.getName();
         this.description = product.getDescription();
@@ -47,5 +49,6 @@ public class ProductDetailDTO {
         this.keywords.addAll(keywords.stream().map(Keyword::getName).toList());
         this.status = product.getStatus();
         this.likeCount = product.getLikeCount();
+        this.likeStatus = likeStatus;
     }
 }

--- a/api/src/main/java/clov3r/api/domain/DTO/ProductDetailDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/ProductDetailDTO.java
@@ -28,6 +28,7 @@ public class ProductDetailDTO {
 
     private List<String> keywords = new ArrayList<>();
     private ProductStatus status;
+    private int likeCount;
 
     // 상세 조회시 사용
     public ProductDetailDTO(Product product, List<Keyword> keywords, Category category) {
@@ -45,5 +46,6 @@ public class ProductDetailDTO {
         this.categoryDisplayName = product.getCategoryDisplayName();
         this.keywords.addAll(keywords.stream().map(Keyword::getName).toList());
         this.status = product.getStatus();
+        this.likeCount = product.getLikeCount();
     }
 }

--- a/api/src/main/java/clov3r/api/domain/DTO/ProductSummaryDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/ProductSummaryDTO.java
@@ -1,5 +1,6 @@
 package clov3r.api.domain.DTO;
 
+import clov3r.api.domain.data.status.LikeStatus;
 import clov3r.api.domain.data.status.ProductStatus;
 import clov3r.api.domain.entity.Product;
 import lombok.AllArgsConstructor;
@@ -19,14 +20,25 @@ public class ProductSummaryDTO {
     private String thumbnailUrl;
     private int likeCount;
     private ProductStatus status;
+    private LikeStatus likeStatus;
 
     // 리스트 조회시 사용
-    public ProductSummaryDTO(Product product) {
+    public ProductSummaryDTO(Product product, LikeStatus likeStatus) {
         this.idx = product.getIdx();
         this.name = product.getName();
         this.originalPrice = product.getOriginalPrice();
 //        this.currentPrice = product.getCurrentPrice();
 //        this.discountRate = product.getDiscountRate();
+        this.thumbnailUrl = product.getThumbnailUrl();
+        this.status = product.getStatus();
+        this.likeCount = product.getLikeCount();
+        this.likeStatus = likeStatus;
+    }
+
+    public ProductSummaryDTO(Product product) {
+        this.idx = product.getIdx();
+        this.name = product.getName();
+        this.originalPrice = product.getOriginalPrice();
         this.thumbnailUrl = product.getThumbnailUrl();
         this.status = product.getStatus();
         this.likeCount = product.getLikeCount();

--- a/api/src/main/java/clov3r/api/domain/DTO/ProductSummaryDTO.java
+++ b/api/src/main/java/clov3r/api/domain/DTO/ProductSummaryDTO.java
@@ -29,5 +29,6 @@ public class ProductSummaryDTO {
 //        this.discountRate = product.getDiscountRate();
         this.thumbnailUrl = product.getThumbnailUrl();
         this.status = product.getStatus();
+        this.likeCount = product.getLikeCount();
     }
 }

--- a/api/src/main/java/clov3r/api/domain/data/status/LikeStatus.java
+++ b/api/src/main/java/clov3r/api/domain/data/status/LikeStatus.java
@@ -1,0 +1,6 @@
+package clov3r.api.domain.data.status;
+
+public enum LikeStatus {
+  LIKE,
+  NONE
+}

--- a/api/src/main/java/clov3r/api/domain/entity/Product.java
+++ b/api/src/main/java/clov3r/api/domain/entity/Product.java
@@ -1,7 +1,9 @@
 package clov3r.api.domain.entity;
 
 import clov3r.api.domain.data.Gender;
+import clov3r.api.domain.data.status.LikeStatus;
 import clov3r.api.domain.data.status.ProductStatus;
+import clov3r.api.repository.ProductLikeRepository;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -76,5 +78,9 @@ public class Product extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
+
+    @Column(name = "like_count")
+    private int likeCount;
+
 
 }

--- a/api/src/main/java/clov3r/api/domain/entity/ProductLike.java
+++ b/api/src/main/java/clov3r/api/domain/entity/ProductLike.java
@@ -1,0 +1,38 @@
+package clov3r.api.domain.entity;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import clov3r.api.domain.data.status.LikeStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+@Builder
+@Getter
+@Entity
+public class ProductLike extends BaseEntity {
+  @Id @GeneratedValue(strategy = IDENTITY)
+  private Long idx;
+  @Column(name = "user_idx")
+  private Long userIdx;
+  @Column(name = "product_idx")
+  private Long productIdx;
+
+  @Setter
+  @Column(name = "like_status")
+  @Enumerated(STRING)
+  private LikeStatus likeStatus;
+
+}

--- a/api/src/main/java/clov3r/api/repository/CollectionRepository.java
+++ b/api/src/main/java/clov3r/api/repository/CollectionRepository.java
@@ -42,8 +42,7 @@ public class CollectionRepository {
           .join(collectionProduct)
           .on(product.idx.eq(collectionProduct.product.idx))
           .where(collectionProduct.collection.idx.eq(collectionIdx)
-              .and(product.status.eq(ProductStatus.ACTIVE))
-              .and(collectionProduct.status.eq(Status.ACTIVE)))
+              .and(product.status.eq(ProductStatus.ACTIVE)))
           .fetch();
 
   }

--- a/api/src/main/java/clov3r/api/repository/ProductLikeRepository.java
+++ b/api/src/main/java/clov3r/api/repository/ProductLikeRepository.java
@@ -1,0 +1,17 @@
+package clov3r.api.repository;
+
+import clov3r.api.domain.data.status.LikeStatus;
+import clov3r.api.domain.entity.ProductLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
+
+  @Query("SELECT pl FROM ProductLike pl WHERE pl.productIdx = :productIdx AND pl.userIdx = :userIdx")
+  ProductLike findProductLike(Long productIdx, Long userIdx);
+
+  @Query("SELECT COUNT(pl) FROM ProductLike pl WHERE pl.productIdx = :productIdx AND pl.likeStatus = :likeStatus")
+  int countByProductIdxAndLikeStatus(Long productIdx, LikeStatus likeStatus);
+}

--- a/api/src/main/java/clov3r/api/repository/ProductLikeRepository.java
+++ b/api/src/main/java/clov3r/api/repository/ProductLikeRepository.java
@@ -1,7 +1,9 @@
 package clov3r.api.repository;
 
 import clov3r.api.domain.data.status.LikeStatus;
+import clov3r.api.domain.entity.Product;
 import clov3r.api.domain.entity.ProductLike;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,4 +16,8 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
 
   @Query("SELECT COUNT(pl) FROM ProductLike pl WHERE pl.productIdx = :productIdx AND pl.likeStatus = :likeStatus")
   int countByProductIdxAndLikeStatus(Long productIdx, LikeStatus likeStatus);
+
+  @Query("SELECT p FROM Product p JOIN ProductLike pl ON p.idx = pl.productIdx WHERE pl.userIdx = :userIdx AND pl.likeStatus = :likeStatus")
+  List<Product> findLikeProductList(Long userIdx, LikeStatus likeStatus);
+
 }

--- a/api/src/main/java/clov3r/api/repository/ProductRepository.java
+++ b/api/src/main/java/clov3r/api/repository/ProductRepository.java
@@ -239,16 +239,9 @@ public class ProductRepository {
      * @param pageSize
      * @return
      */
-    public List<ProductSummaryDTO> findProductListPagination(Long productIdx, int pageSize) {
+    public List<Product> findProductListPagination(Long productIdx, int pageSize) {
         return queryFactory
-                .select(
-                    Projections.fields(ProductSummaryDTO.class,
-                        product.idx,
-                        product.name,
-                        product.originalPrice,
-                        product.currentPrice,
-                        product.discountRate,
-                        product.thumbnailUrl))
+                .select(product)
                 .from(product)
                 .where(ltProduct(productIdx))
                 .orderBy(product.idx.desc())

--- a/api/src/main/java/clov3r/api/repository/ProductRepository.java
+++ b/api/src/main/java/clov3r/api/repository/ProductRepository.java
@@ -288,5 +288,12 @@ public class ProductRepository {
                 .fetch();
     }
 
+    public void updateProductLikeCount(Long productIdx, int likeCount) {
+        queryFactory.update(product)
+                .set(product.likeCount, likeCount)
+                .where(product.idx.eq(productIdx))
+                .execute();
+
+    }
 }
 

--- a/api/src/main/java/clov3r/api/service/ProductService.java
+++ b/api/src/main/java/clov3r/api/service/ProductService.java
@@ -3,8 +3,11 @@ package clov3r.api.service;
 import clov3r.api.domain.DTO.ProductSummaryDTO;
 import clov3r.api.domain.collection.ProductFilter;
 import clov3r.api.domain.collection.ProductSearch;
+import clov3r.api.domain.data.status.LikeStatus;
 import clov3r.api.domain.entity.Product;
+import clov3r.api.domain.entity.ProductLike;
 import clov3r.api.repository.KeywordRepository;
+import clov3r.api.repository.ProductLikeRepository;
 import clov3r.api.repository.ProductRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,57 +19,90 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProductService {
 
-    private final ProductRepository productRepository;
-    private final KeywordRepository keywordRepository;
+  private final ProductRepository productRepository;
+  private final KeywordRepository keywordRepository;
+  private final ProductLikeRepository productLikeRepository;
 
 
-    public List<ProductSummaryDTO> filterProducts(ProductFilter productFilter) {
-        // First Query: Filter by price and gender
-        List<Product> products = productRepository.filterProductsByPrice(productFilter);
-        return products.stream()
-            .map(ProductSummaryDTO::new).toList();
+  public List<ProductSummaryDTO> filterProducts(ProductFilter productFilter) {
+    // First Query: Filter by price and gender
+    List<Product> products = productRepository.filterProductsByPrice(productFilter);
+    return products.stream()
+        .map(ProductSummaryDTO::new).toList();
 
 //        // Second Query: Further filter by keywords if applicable
 //        if (!productSearch.getKeywords().isEmpty()) {
 //            return productRepository.filterProductsByKeywords(initialFilteredProducts, productSearch.getKeywords());
 //        }
 
-    }
+  }
 
-    public Product getProductByIdx(Long productIdx) {
-        Product product = productRepository.findById(productIdx);
+  public Product getProductByIdx(Long productIdx) {
+    Product product = productRepository.findById(productIdx);
 //        System.out.println("product.toString() = " + product.toString());
-        return product;
+    return product;
+  }
+
+  public List<Product> filterProductsWithCategory(ProductSearch productSearch) {
+
+    List<Product> initialFilteredProducts = productRepository.filterProductsByPriceAndGender(
+        productSearch);
+
+    // filter by category and answer keywords
+    List<Product> filterProductsByCategoryKeywords = productRepository.filterProductsByCategoryAndKeywords(
+        initialFilteredProducts, productSearch);
+
+    if (!productSearch.getKeywords().isEmpty()) {
+      return productRepository.filterProductsByKeywords(filterProductsByCategoryKeywords,
+          productSearch.getKeywords());
     }
 
-    public List<Product> filterProductsWithCategory(ProductSearch productSearch) {
+    return initialFilteredProducts;
+  }
 
+  public List<ProductSummaryDTO> getAllProducts() {
+    List<Product> products = productRepository.findAll();
+    return products.stream()
+        .map(ProductSummaryDTO::new).toList();
+  }
 
-        List<Product> initialFilteredProducts = productRepository.filterProductsByPriceAndGender(productSearch);
-
-        // filter by category and answer keywords
-        List<Product> filterProductsByCategoryKeywords = productRepository.filterProductsByCategoryAndKeywords(initialFilteredProducts, productSearch);
-
-        if (!productSearch.getKeywords().isEmpty()) {
-            return productRepository.filterProductsByKeywords(filterProductsByCategoryKeywords, productSearch.getKeywords());
-        }
-
-        return initialFilteredProducts;
-    }
-
-    public List<ProductSummaryDTO> getAllProducts() {
-        List<Product> products = productRepository.findAll();
-        return products.stream()
-                .map(ProductSummaryDTO::new).toList();
-    }
-
-    public List<ProductSummaryDTO> getProductListPagination(Long lastProductIdx, int pageSize) {
-        return productRepository.findProductListPagination(lastProductIdx, pageSize);
-    }
+  public List<ProductSummaryDTO> getProductListPagination(Long lastProductIdx, int pageSize) {
+    return productRepository.findProductListPagination(lastProductIdx, pageSize);
+  }
 
   public List<ProductSummaryDTO> searchProduct(String searchKeyword) {
     List<Product> products = productRepository.searchProduct(searchKeyword);
     return products.stream()
         .map(ProductSummaryDTO::new).toList();
   }
+
+  @Transactional
+  public void likeProduct(Long productIdx, Long userIdx) {
+    ProductLike productLike = productLikeRepository.findProductLike(productIdx, userIdx);
+    if (productLike != null) {
+      if (productLike.getLikeStatus().equals(LikeStatus.LIKE)) {
+        productLike.setLikeStatus(LikeStatus.NONE);
+      } else {
+        productLike.setLikeStatus(LikeStatus.LIKE);
+      }
+    } else {
+      ProductLike newProductLike = ProductLike.builder()
+          .productIdx(productIdx)
+          .userIdx(userIdx)
+          .likeStatus(LikeStatus.LIKE)
+          .build();
+      newProductLike.createBaseEntity();
+      productLikeRepository.save(newProductLike);
+    }
+    updateProductLikeCount(productIdx);
+  }
+
+  public int getLikeCount(Long productIdx) {
+    return productLikeRepository.countByProductIdxAndLikeStatus(productIdx, LikeStatus.LIKE);
+  }
+
+  public void updateProductLikeCount(Long productIdx) {
+    productRepository.updateProductLikeCount(productIdx, getLikeCount(productIdx));
+  }
+
 }


### PR DESCRIPTION
# [ONE-855] 상품 좋아요 API, 유저별 좋아요 상품 리스트 조회 API
## 🔑 Key Change 
- 로그인 유저만 좋아요 가능
- ProductLike 엔티티 생성, product_like 테이블 생성
- product 테이블에 like_count 컬럼 생성
- 좋아요 처음 눌렀을 때 좋아요로 상태 변경, 다시 눌렀을 때 좋아요 삭제
- 좋아요 API 요청 마지막에 상품 like count세서 DB에 저장
- 유저가 좋아요 누른 상품 리스트 조회
- 로그인 상태로 상품을 조회했을 시 좋아요 여부 함께 조회됨(추천결과, 컬렉션 조회, 상품 조회, 상품 상세 조회 등등, 선물바구니 내 제품 조회 제외)

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 

[ONE-855]: https://clov3r.atlassian.net/browse/ONE-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ