### PR TITLE
Feature/user info

### DIFF
--- a/api/src/main/java/clov3r/api/auth/controller/AuthController.java
+++ b/api/src/main/java/clov3r/api/auth/controller/AuthController.java
@@ -171,4 +171,14 @@ public class AuthController {
         return ResponseEntity.ok("탈퇴가 완료되었습니다.");
     }
 
+    @Tag(name = "계정 API", description = "회원가입/로그인 관련 API 목록")
+    @Operation(summary = "마케팅 수신 동의 변경", description = "마케팅 수신 동의 여부를 변경합니다.")
+    @PatchMapping("/api/v2/marketing")
+    public ResponseEntity<String> changeMarketing(
+        @Parameter(hidden = true) @Auth Long userIdx
+    ) {
+        Boolean isAgreeMarketing = userService.changeMarketing(userIdx);
+        return ResponseEntity.ok("마케팅 수신 동의 : " + isAgreeMarketing);
+    }
+
 }

--- a/api/src/main/java/clov3r/api/auth/controller/AuthController.java
+++ b/api/src/main/java/clov3r/api/auth/controller/AuthController.java
@@ -23,7 +23,6 @@ import clov3r.api.common.error.exception.BaseExceptionV2;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -136,6 +135,7 @@ public class AuthController {
             .profileImg(user.getProfileImg())
             .gender(user.getGender())
             .birthDate(user.getBirthDate())
+            .isAgreeMarketing(user.getIsAgreeMarketing())
             .build();
         return ResponseEntity.ok(newUser);
     }

--- a/api/src/main/java/clov3r/api/auth/domain/dto/UserDTO.java
+++ b/api/src/main/java/clov3r/api/auth/domain/dto/UserDTO.java
@@ -21,6 +21,7 @@ public class UserDTO {
     private Gender gender;
     private LocalDate birthDate;
     private String phoneNumber;
+    private Boolean isAgreeMarketing;
 
     public UserDTO(User user) {
         this.idx = user.getIdx();
@@ -31,5 +32,6 @@ public class UserDTO {
         this.gender = user.getGender();
         this.birthDate = user.getBirthDate();
         this.phoneNumber = user.getPhoneNumber();
+        this.isAgreeMarketing = user.getIsAgreeMarketing();
     }
 }

--- a/api/src/main/java/clov3r/api/auth/domain/entity/User.java
+++ b/api/src/main/java/clov3r/api/auth/domain/entity/User.java
@@ -43,11 +43,14 @@ public class User extends BaseEntity {
     private Gender gender;  //  product gender enum 과 다름
 
     private String age;
+
+    @Column(name = "birth_date")
     private LocalDate birthDate;
 
     @Column(name = "is_agree_marketing")
     private Boolean isAgreeMarketing;
 
+    @Column(name = "refresh_token")
     private String refreshToken;
 
     @Enumerated(EnumType.STRING)

--- a/api/src/main/java/clov3r/api/auth/domain/entity/User.java
+++ b/api/src/main/java/clov3r/api/auth/domain/entity/User.java
@@ -45,6 +45,9 @@ public class User extends BaseEntity {
     private String age;
     private LocalDate birthDate;
 
+    @Column(name = "is_agree_marketing")
+    private Boolean isAgreeMarketing;
+
     private String refreshToken;
 
     @Enumerated(EnumType.STRING)

--- a/api/src/main/java/clov3r/api/auth/domain/request/SignupRequest.java
+++ b/api/src/main/java/clov3r/api/auth/domain/request/SignupRequest.java
@@ -10,4 +10,5 @@ public class SignupRequest {
     private String nickname;
     private LocalDate birthDate;
     private Gender gender;
+    private Boolean isAgreeMarketing;
 }

--- a/api/src/main/java/clov3r/api/auth/service/UserService.java
+++ b/api/src/main/java/clov3r/api/auth/service/UserService.java
@@ -10,6 +10,8 @@ import clov3r.api.auth.domain.request.UpdateUserRequest;
 import clov3r.api.common.error.exception.BaseExceptionV2;
 import clov3r.api.auth.repository.UserRepository;
 import clov3r.api.common.service.S3Service;
+import clov3r.api.friend.domain.dto.OtherUserDTO;
+import clov3r.api.friend.service.FriendService;
 import clov3r.api.notification.service.NotificationService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final NotificationService notificationService;
     private final S3Service s3Service;
+    private final FriendService friendService;
 
     public UserDTO getUser(Long userIdx) {
         User user = userRepository.findByUserIdx(userIdx);
@@ -90,4 +93,10 @@ public class UserService {
         user.setIsAgreeMarketing(!user.getIsAgreeMarketing());
         return user.getIsAgreeMarketing();
     }
+
+    public OtherUserDTO getOtherUser(Long userIdx, Long friendIdx) {
+        User user = userRepository.findByUserIdx(friendIdx);
+        return new OtherUserDTO(user, friendService.isFriend(userIdx, friendIdx));
+    }
+
 }

--- a/api/src/main/java/clov3r/api/auth/service/UserService.java
+++ b/api/src/main/java/clov3r/api/auth/service/UserService.java
@@ -67,6 +67,7 @@ public class UserService {
         // upload image if exists
         if (profileImage != null) {
             String imageUrl = updateProfileImage(profileImage, userIdx);
+            user.setProfileImg(imageUrl);
         }
         return user;
     }

--- a/api/src/main/java/clov3r/api/auth/service/UserService.java
+++ b/api/src/main/java/clov3r/api/auth/service/UserService.java
@@ -83,4 +83,10 @@ public class UserService {
         user.setPhoneNumber(phoneNumber);
     }
 
+    @Transactional
+    public Boolean changeMarketing(Long userIdx) {
+        User user = userRepository.findByUserIdx(userIdx);
+        user.setIsAgreeMarketing(!user.getIsAgreeMarketing());
+        return user.getIsAgreeMarketing();
+    }
 }

--- a/api/src/main/java/clov3r/api/auth/service/UserService.java
+++ b/api/src/main/java/clov3r/api/auth/service/UserService.java
@@ -40,6 +40,7 @@ public class UserService {
         user.setNickname(signupRequest.getNickname());
         user.setGender(signupRequest.getGender());
         user.setBirthDate(signupRequest.getBirthDate());
+        user.setIsAgreeMarketing(signupRequest.getIsAgreeMarketing());
         userRepository.save(user);
 
 //        notificationService.sendSignupCompleteNotification(user);

--- a/api/src/main/java/clov3r/api/common/domain/entity/BaseEntity.java
+++ b/api/src/main/java/clov3r/api/common/domain/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/api/src/main/java/clov3r/api/friend/controller/FriendController.java
+++ b/api/src/main/java/clov3r/api/friend/controller/FriendController.java
@@ -1,5 +1,7 @@
 package clov3r.api.friend.controller;
 
+import clov3r.api.auth.service.UserService;
+import clov3r.api.friend.domain.dto.OtherUserDTO;
 import clov3r.api.friend.domain.dto.RequestFriendDTO;
 import clov3r.api.common.error.errorcode.CustomErrorCode;
 import clov3r.api.common.error.exception.BaseExceptionV2;
@@ -30,6 +32,7 @@ public class FriendController {
   private final FriendService friendService;
   private final FriendReqRepository friendReqRepository;
   private final UserRepository userRepository;
+  private final UserService userService;
 
   @Tag(name = "친구관리 API", description = "친구 관련 API")
   @Operation(summary = "친구 요청", description = "친구 요청을 보냅니다.(서비스 가입 유저에게만 가능)")
@@ -144,6 +147,17 @@ public class FriendController {
   ) {
     List<FriendDTO> friends = friendService.getFriends(userIdx);
     return ResponseEntity.ok(friends);
+  }
+
+  @Tag(name = "친구관리 API", description = "친구 관련 API")
+  @Operation(summary = "다른 유저 프로필 확인", description = "친구 혹은 다른 유저의 프로필을 조회합니다.")
+  @GetMapping("/api/v2/friends/{friendIdx}")
+  public ResponseEntity<OtherUserDTO> getFriendProfile(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx
+  ) {
+    OtherUserDTO otherUserDTO = userService.getOtherUser(userIdx, friendIdx);
+    return ResponseEntity.ok(otherUserDTO);
   }
 
 }

--- a/api/src/main/java/clov3r/api/friend/domain/dto/FriendReqDTO.java
+++ b/api/src/main/java/clov3r/api/friend/domain/dto/FriendReqDTO.java
@@ -1,6 +1,5 @@
 package clov3r.api.friend.domain.dto;
 
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/api/src/main/java/clov3r/api/friend/domain/dto/OtherUserDTO.java
+++ b/api/src/main/java/clov3r/api/friend/domain/dto/OtherUserDTO.java
@@ -1,0 +1,27 @@
+package clov3r.api.friend.domain.dto;
+
+import clov3r.api.auth.domain.entity.User;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OtherUserDTO {
+  private Long idx;
+  private String nickName;
+  private String profileImg;
+  private LocalDate birthDate;
+  private Boolean isFriend;
+
+  public OtherUserDTO(User user, Boolean isFriend) {
+    this.idx = user.getIdx();
+    this.nickName = user.getNickname();
+    this.profileImg = user.getProfileImg();
+    this.birthDate = user.getBirthDate();
+    this.isFriend = isFriend;
+  }
+
+}

--- a/api/src/main/java/clov3r/api/friend/domain/dto/OtherUserDTO.java
+++ b/api/src/main/java/clov3r/api/friend/domain/dto/OtherUserDTO.java
@@ -3,7 +3,6 @@ package clov3r.api.friend.domain.dto;
 import clov3r.api.auth.domain.entity.User;
 import java.time.LocalDate;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/api/src/main/java/clov3r/api/friend/domain/entity/Friendship.java
+++ b/api/src/main/java/clov3r/api/friend/domain/entity/Friendship.java
@@ -13,15 +13,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Builder
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "friendship")
 public class Friendship extends BaseEntity {
 
@@ -39,8 +42,4 @@ public class Friendship extends BaseEntity {
   @Setter
   @Enumerated(EnumType.STRING)
   private Status status;
-
-  public Friendship() {
-
-  }
 }

--- a/api/src/main/java/clov3r/api/friend/service/FriendService.java
+++ b/api/src/main/java/clov3r/api/friend/service/FriendService.java
@@ -1,6 +1,5 @@
 package clov3r.api.friend.service;
 
-import clov3r.api.auth.domain.entity.User;
 import clov3r.api.friend.domain.dto.FriendDTO;
 import clov3r.api.friend.domain.dto.FriendReqDTO;
 import clov3r.api.friend.domain.data.FriendReqStatus;

--- a/api/src/main/java/clov3r/api/friend/service/FriendService.java
+++ b/api/src/main/java/clov3r/api/friend/service/FriendService.java
@@ -1,5 +1,6 @@
 package clov3r.api.friend.service;
 
+import clov3r.api.auth.domain.entity.User;
 import clov3r.api.friend.domain.dto.FriendDTO;
 import clov3r.api.friend.domain.dto.FriendReqDTO;
 import clov3r.api.friend.domain.data.FriendReqStatus;
@@ -138,5 +139,4 @@ public class FriendService {
             .build())
         .toList();
   }
-
 }

--- a/api/src/main/java/clov3r/api/giftbox/domain/status/InvitationStatus.java
+++ b/api/src/main/java/clov3r/api/giftbox/domain/status/InvitationStatus.java
@@ -3,4 +3,5 @@ package clov3r.api.giftbox.domain.status;
 public enum InvitationStatus {
     PENDING,  // 초대 대기중
     ACCEPTED, // 초대 수락
+    DELETED, // 삭제
 }

--- a/api/src/main/java/clov3r/api/giftbox/repository/GiftboxUserRepository.java
+++ b/api/src/main/java/clov3r/api/giftbox/repository/GiftboxUserRepository.java
@@ -1,6 +1,8 @@
 package clov3r.api.giftbox.repository;
 
+import clov3r.api.auth.domain.entity.User;
 import clov3r.api.giftbox.domain.entity.GiftboxUser;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,4 +12,7 @@ public interface GiftboxUserRepository extends JpaRepository<GiftboxUser, Long> 
 
   @Query("select gu.sender.idx from GiftboxUser gu where gu.idx = :invitationIdx")
   Long findSenderByInvitationIdx(Long invitationIdx);
+
+  @Query("select gu from GiftboxUser gu where gu.user.idx = :userIdx")
+  List<GiftboxUser> findByUser(Long userIdx);
 }

--- a/api/src/main/java/clov3r/api/notification/domain/entity/Notification.java
+++ b/api/src/main/java/clov3r/api/notification/domain/entity/Notification.java
@@ -1,6 +1,7 @@
 package clov3r.api.notification.domain.entity;
 
 import clov3r.api.auth.domain.entity.User;
+import clov3r.api.common.domain.entity.BaseEntity;
 import clov3r.api.notification.domain.status.NotiStatus;
 import clov3r.api.notification.domain.data.ActionType;
 import jakarta.persistence.Column;
@@ -23,10 +24,11 @@ import lombok.Setter;
 
 @Entity
 @Builder
+@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification {
+public class Notification extends BaseEntity {
 
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
@@ -53,14 +55,12 @@ public class Notification {
   @Column(name = "platform_type")
   private String platformType;
 
-  @Column(name = "created_at")
-  private ZonedDateTime createdAt;
-  @Setter
+  @Column(name = "read_at")
   private ZonedDateTime readAt;
-  @Setter
+
+  @Column(name = "sent_at")
   private ZonedDateTime sentAt;
 
-  @Setter
   @Column(name = "noti_status")
   @Enumerated(EnumType.STRING)
   private NotiStatus notiStatus;

--- a/api/src/main/java/clov3r/api/notification/domain/status/NotiStatus.java
+++ b/api/src/main/java/clov3r/api/notification/domain/status/NotiStatus.java
@@ -1,5 +1,6 @@
 package clov3r.api.notification.domain.status;
 
 public enum NotiStatus {
-  CREATED, SENT, READ
+  CREATED, SENT, READ,
+  DELETED
 }

--- a/api/src/main/java/clov3r/api/notification/repository/NotificationRepository.java
+++ b/api/src/main/java/clov3r/api/notification/repository/NotificationRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-  @Query("SELECT n FROM Notification n WHERE n.receiver.idx = :userIdx ORDER BY n.createdAt DESC")
+  @Query("SELECT n FROM Notification n WHERE n.receiver.idx = :userIdx AND n.notiStatus != 'DELETED' ORDER BY n.createdAt DESC")
   List<Notification> findAllByUserId(Long userIdx);
 
 }

--- a/api/src/main/java/clov3r/api/notification/service/NotificationService.java
+++ b/api/src/main/java/clov3r/api/notification/service/NotificationService.java
@@ -102,9 +102,9 @@ public class NotificationService {
         .body(friendReq.getFrom().getNickname() + "님이 친구 요청을 보냈습니다.")
         .actionType(ActionType.FRIEND_REQUEST)
         .platformType("FCM")
-        .createdAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
         .notiStatus(NotiStatus.CREATED)
         .build();
+    notification.createBaseEntity();
     applicationEventPublisher.publishEvent(notification);
     notificationRepository.save(notification);
   }
@@ -123,9 +123,9 @@ public class NotificationService {
         .title("친구 요청 수락")
         .body(friendReq.getTo().getNickname() + "님이 친구 요청을 수락했습니다.")
         .actionType(ActionType.FRIEND_ACCEPTANCE)
-        .createdAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
         .notiStatus(NotiStatus.CREATED)
         .build();
+    notification.createBaseEntity();
     applicationEventPublisher.publishEvent(notification);
     notificationRepository.save(notification);
     return notification;
@@ -166,9 +166,9 @@ public class NotificationService {
         .body(userRepository.findByUserIdx(userIdx).getNickname() + "님이 ["+giftbox.getName()+"] 선물바구니 초대를 수락했습니다.")
         .actionType(ActionType.GIFTBOX_ACCEPTANCE)
         .platformType("FCM")
-        .createdAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
         .notiStatus(NotiStatus.CREATED)
         .build();
+    notification.createBaseEntity();
     applicationEventPublisher.publishEvent(notification);
     notificationRepository.save(notification);
     return notification;
@@ -191,11 +191,11 @@ public class NotificationService {
           .body("선물바구니 ["+giftbox.getName()+"] 에서 받고 싶은 선물 물어보기가 완료되었습니다.")
           .actionType(ActionType.GIFT_ASK_COMPLETE)
           .platformType("FCM")
-          .createdAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
           .notiStatus(NotiStatus.CREATED)
           .build();
     }).toList();
     for (Notification notification : notificationList) {
+      notification.createBaseEntity();
       applicationEventPublisher.publishEvent(notification);
       notificationRepository.save(notification);
     }


### PR DESCRIPTION
# [ONE-01] 회원 가입시 마케팅 정보 수신 동의
## 🔑 Key Change 
- 회원 가입시 마케팅 정보 수신 동의 여부 boolean값으로 입력
- 마케팅 정보 수신 동의 여부 변경 API

# [ONE-02] 회원 수정 API
## 🔑 Key Change 
- 회원 정보 수정할 때 이미지가 오면 s3 저장후 이미지 url을 user 정보에 저장
- 유저 정보에 새로운 이미지 저장 부분이 누락되어 있어 추가함

# [ONE-03] 다른 유저 프로필 조회 API
## 🔑 Key Change 
- 다른 유저의 프로필 정보 조회(idx, 닉네임, 프로필 이미지, 생일, 친구여부)
- 친구 목록 조회할 때에는 (idx, 이름, 닉네임, 프로필 이미지, 생일)

# [ONE-04] 회원 탈퇴 -> 유저 정보 삭제
## 🔑 Key Change 
- 회원 탈퇴할 때 관련 유저 정보 status를 DELETED로 수정
- 선물바구니 참여 이력, 알림 수신 및 발신 이력

## 🖼️ Screenshots (if necessary)
![image]()


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 
- 회원 정보 수정 부분 이미지 입력은 선물바구니 생성이랑 동일한데, 입력받을 때 어떤 부분을 수정해야 되는지?
- 아님 입력한 이미지가 저장이 안돼서 클라이언트 단에서 안 보여서 그런건가?
