### PR TITLE
Feature/time attack

### DIFF
--- a/api/src/main/java/clov3r/api/common/error/errorcode/CustomErrorCode.java
+++ b/api/src/main/java/clov3r/api/common/error/errorcode/CustomErrorCode.java
@@ -35,6 +35,7 @@ public enum CustomErrorCode implements ErrorCode {
   DUPLICATE_NICKNAME(BAD_REQUEST, "중복된 닉네임입니다."),
   SEARCH_KEYWORD_ERROR(BAD_REQUEST, "검색 키워드 입력값은 2글자 이상이어야 합니다."),
   CANNOT_DELETE_OTHERS_COMMENT(BAD_REQUEST, "다른 사용자의 댓글은 삭제할 수 없습니다."),
+  TIME_ATTACK_ALARM_OFF(BAD_REQUEST, "타임어택 알람이 꺼져있습니다."),
 
   /**
    * token 오류
@@ -88,7 +89,8 @@ public enum CustomErrorCode implements ErrorCode {
   SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버와의 연결에 실패하였습니다."),
   DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 연결에 실패하였습니다."),
   DATABASE_ERROR_QUERY(INTERNAL_SERVER_ERROR, "데이터베이스 쿼리 실행이 실패하였습니다."),
-  KAKAO_ALARM_ERROR(INTERNAL_SERVER_ERROR, "카카오 알람 전송에 실패하였습니다."),;
+  KAKAO_ALARM_ERROR(INTERNAL_SERVER_ERROR, "카카오 알람 전송에 실패하였습니다."),
+  ;
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/api/src/main/java/clov3r/api/common/error/errorcode/CustomErrorCode.java
+++ b/api/src/main/java/clov3r/api/common/error/errorcode/CustomErrorCode.java
@@ -62,6 +62,7 @@ public enum CustomErrorCode implements ErrorCode {
   GIFTBOX_PRODUCT_NOT_FOUND(NOT_FOUND, "선물바구니 상품을 찾을 수 없습니다."),
   DEVICE_TOKEN_NOT_FOUND(NOT_FOUND, "디바이스 토큰을 찾을 수 없습니다."),
   NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림을 찾을 수 없습니다."),
+  NOT_FOUND_FRIENDSHIP(NOT_FOUND, "친구 관계가 존재하지 않습니다."),
 
   /**
    * FORBIDDEN

--- a/api/src/main/java/clov3r/api/friend/repository/FriendshipCustomRepository.java
+++ b/api/src/main/java/clov3r/api/friend/repository/FriendshipCustomRepository.java
@@ -1,9 +1,12 @@
 package clov3r.api.friend.repository;
 
 import clov3r.domain.domains.entity.Friendship;
+import clov3r.domain.domains.entity.User;
 import java.util.List;
 
 public interface FriendshipCustomRepository {
   Friendship findByUserIdxAndFriendIdx(Long userIdx, Long friendIdx);
   List<Friendship> findByUserIdx(Long userIdx);
+
+  List<User> findBirthdayFriends(Long userIdx, int days);
 }

--- a/api/src/main/java/clov3r/api/friend/repository/FriendshipCustomRepositoryImpl.java
+++ b/api/src/main/java/clov3r/api/friend/repository/FriendshipCustomRepositoryImpl.java
@@ -3,9 +3,12 @@ package clov3r.api.friend.repository;
 import static clov3r.domain.domains.entity.QFriendship.friendship;
 
 import clov3r.domain.domains.entity.Friendship;
+import clov3r.domain.domains.entity.User;
 import clov3r.domain.domains.status.Status;
 import clov3r.domain.domains.status.UserStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.MonthDay;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -31,6 +34,32 @@ public class FriendshipCustomRepositoryImpl implements FriendshipCustomRepositor
         .where(friendship.user.idx.eq(userIdx))
         .where(friendship.status.eq(Status.ACTIVE)
             .and(friendship.friend.status.eq(UserStatus.ACTIVE)))
+        .fetch();
+  }
+
+  @Override
+  public List<User> findBirthdayFriends(Long userIdx, int days) {
+    LocalDate now = LocalDate.now();
+    MonthDay today = MonthDay.from(now);
+    MonthDay last = MonthDay.from(now.plusDays(days));
+    boolean isChangeMonth =
+        (today.getMonth().getValue() == 12 && last.getMonth().getValue() == 1)
+        || (today.getMonth().getValue() < last.getMonth().getValue());
+
+    return queryFactory.select(friendship.friend)
+        .from(friendship)
+        .where(friendship.user.idx.eq(userIdx))
+        .where(friendship.status.eq(Status.ACTIVE)
+            .and(friendship.friend.status.eq(UserStatus.ACTIVE)))
+        .where(isChangeMonth ?
+            (friendship.friend.birthDate.month().eq(last.getMonthValue())
+            .and(friendship.friend.birthDate.dayOfMonth().between(1, last.getDayOfMonth())))
+            .or(friendship.friend.birthDate.month().eq(today.getMonthValue())
+                .and(friendship.friend.birthDate.dayOfMonth().between(today.getDayOfMonth(), today.getDayOfMonth()+days)))
+            :
+                friendship.friend.birthDate.month().eq(today.getMonthValue())
+            .and(friendship.friend.birthDate.dayOfMonth().between(today.getDayOfMonth(), today.getDayOfMonth()+days))
+        )
         .fetch();
   }
 

--- a/api/src/main/java/clov3r/api/product/service/ProductService.java
+++ b/api/src/main/java/clov3r/api/product/service/ProductService.java
@@ -150,12 +150,12 @@ public class ProductService {
     return detailImageList;
   }
 
-  public Product getRandomProduct(List<Product> friendWishList, Long excludeProductId) {
+  public Product getRandomProduct(List<Product> friendWishList, Long excludeProductIdx) {
     Product randomProduct = null;
     while (randomProduct == null) {
       int randomIndex = (int) (Math.random() * friendWishList.size());
       randomProduct = friendWishList.get(randomIndex);
-      if (randomProduct.getIdx().equals(excludeProductId)) {
+      if (randomProduct.getIdx().equals(excludeProductIdx)) {
         randomProduct = null;
       }
     }

--- a/api/src/main/java/clov3r/api/product/service/ProductService.java
+++ b/api/src/main/java/clov3r/api/product/service/ProductService.java
@@ -150,4 +150,16 @@ public class ProductService {
     return detailImageList;
   }
 
+  public Product getRandomProduct(List<Product> friendWishList, Long excludeProductId) {
+    Product randomProduct = null;
+    while (randomProduct == null) {
+      int randomIndex = (int) (Math.random() * friendWishList.size());
+      randomProduct = friendWishList.get(randomIndex);
+      if (randomProduct.getIdx().equals(excludeProductId)) {
+        randomProduct = null;
+      }
+    }
+    return randomProduct;
+  }
+
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
@@ -1,19 +1,29 @@
 package clov3r.api.timeattack.controller;
 
 import clov3r.api.auth.security.Auth;
+import clov3r.api.product.domain.dto.ProductSummaryDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
+@Tag(name = "타임어택 API", description = "타임어택 관련 API")
 public interface TimeAttackController {
 
-  @Tag(name = "타임어택 API", description = "타임어택 관련 API")
+
   @Operation(summary = "타임어택 알람 토글", description = "타임어택 알람을 토글합니다.")
   @PostMapping("/api/v2/friends/{friendIdx}/time-attack/toggle")
   ResponseEntity<String> toggleTimeAttackAlarm(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx
+  );
+
+  @Operation(summary = "친구의 위시리스트 목록 전체 조회", description = "친구의 위시리스트 목록을 전체 조회합니다.")
+  @PostMapping("/api/v2/friends/{friendIdx}/wish-list")
+  ResponseEntity<List<ProductSummaryDTO>> getFriendWishList(
       @PathVariable Long friendIdx,
       @Parameter(hidden = true) @Auth Long userIdx
   );

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
@@ -1,6 +1,7 @@
 package clov3r.api.timeattack.controller;
 
 import clov3r.api.auth.security.Auth;
+import clov3r.api.friend.domain.dto.FriendDTO;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -38,4 +39,9 @@ public interface TimeAttackController {
       @Parameter(description = "제외할 제품 ID") @RequestParam(required = false) Long excludeProductId
   );
 
+  @Operation(summary = "7일 이내 생일인 친구 조회", description = "7일 이내 생일인 친구를 조회합니다.")
+  @GetMapping("/api/v2/friends/birthday")
+  ResponseEntity<List<FriendDTO>> getBirthdayFriends(
+      @Parameter(hidden = true) @Auth Long userIdx
+  );
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
@@ -36,7 +36,7 @@ public interface TimeAttackController {
   ResponseEntity<ProductSummaryDTO> getFriendWishListRandomProduct(
       @PathVariable Long friendIdx,
       @Parameter(hidden = true) @Auth Long userIdx,
-      @Parameter(description = "제외할 제품 ID") @RequestParam(required = false) Long excludeProductId
+      @Parameter(description = "제외할 제품 IDX") @RequestParam(required = false) Long excludeProductId
   );
 
   @Operation(summary = "7일 이내 생일인 친구 조회", description = "7일 이내 생일인 친구를 조회합니다.")

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "타임어택 API", description = "타임어택 관련 API")
 public interface TimeAttackController {
@@ -22,10 +24,18 @@ public interface TimeAttackController {
   );
 
   @Operation(summary = "친구의 위시리스트 목록 전체 조회", description = "친구의 위시리스트 목록을 전체 조회합니다.")
-  @PostMapping("/api/v2/friends/{friendIdx}/wish-list")
+  @GetMapping("/api/v2/friends/{friendIdx}/wish-list")
   ResponseEntity<List<ProductSummaryDTO>> getFriendWishList(
       @PathVariable Long friendIdx,
       @Parameter(hidden = true) @Auth Long userIdx
+  );
+
+  @Operation(summary = "친구의 위시리스트 랜덤제품 조회", description = "친구의 위시리스트 목록에서 제품을 랜덤으로 조회합니다.")
+  @GetMapping("/api/v2/friends/{friendIdx}/wish-list/random")
+  ResponseEntity<ProductSummaryDTO> getFriendWishListRandomProduct(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx,
+      @Parameter(description = "제외할 제품 ID") @RequestParam(required = false) Long excludeProductId
   );
 
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
@@ -1,0 +1,21 @@
+package clov3r.api.timeattack.controller;
+
+import clov3r.api.auth.security.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+public interface TimeAttackController {
+
+  @Tag(name = "타임어택 API", description = "타임어택 관련 API")
+  @Operation(summary = "타임어택 알람 토글", description = "타임어택 알람을 토글합니다.")
+  @PostMapping("/api/v2/friends/{friendIdx}/time-attack/toggle")
+  ResponseEntity<String> toggleTimeAttackAlarm(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx
+  );
+
+}

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -7,9 +7,13 @@ import clov3r.api.common.error.errorcode.CustomErrorCode;
 import clov3r.api.common.error.exception.BaseExceptionV2;
 import clov3r.api.friend.repository.FriendshipRepository;
 import clov3r.api.friend.service.FriendService;
+import clov3r.api.product.domain.dto.ProductSummaryDTO;
+import clov3r.api.product.service.ProductService;
 import clov3r.api.timeattack.service.TimeAttackService;
 import clov3r.domain.domains.entity.Friendship;
+import clov3r.domain.domains.entity.Product;
 import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,8 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TimeAttackControllerImpl implements TimeAttackController {
   private final TimeAttackService timeAttackService;
-  private final FriendService friendService;
   private final FriendshipRepository friendshipRepository;
+  private final ProductService productService;
 
   @Override
   public ResponseEntity<String> toggleTimeAttackAlarm(
@@ -33,5 +37,26 @@ public class TimeAttackControllerImpl implements TimeAttackController {
     }
     Boolean timeAttackAlarm = timeAttackService.toggleTimeAttackAlarm(friendship);
     return ResponseEntity.ok(userIdx + "의 친구 " + friendIdx + "의 타임어택 알람 여부 :" + timeAttackAlarm);
+  }
+
+  @Override
+  public ResponseEntity<List<ProductSummaryDTO>> getFriendWishList(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx
+  ) {
+    Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx);
+    if (friendship == null) {
+      throw new BaseExceptionV2(NOT_FOUND_FRIENDSHIP);
+    }
+    if (!friendship.getTimeAttackAlarm()) {
+      throw new BaseExceptionV2(TIME_ATTACK_ALARM_OFF);
+    }
+    List<Product> friendWishList = timeAttackService.getFriendWishList(friendIdx);
+    List<ProductSummaryDTO> productSummaryDTOList = friendWishList.stream()
+        .map(product -> new ProductSummaryDTO(
+            product,
+            productService.getLikeStatus(product.getIdx(), userIdx)
+        )).toList();
+    return ResponseEntity.ok(productSummaryDTOList);
   }
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -59,4 +59,27 @@ public class TimeAttackControllerImpl implements TimeAttackController {
         )).toList();
     return ResponseEntity.ok(productSummaryDTOList);
   }
+
+  @Override
+  public ResponseEntity<ProductSummaryDTO> getFriendWishListRandomProduct(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx,
+      @Parameter(description = "제외할 제품 ID") Long excludeProductId
+  ) {
+    Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx);
+    if (friendship == null) {
+      throw new BaseExceptionV2(NOT_FOUND_FRIENDSHIP);
+    }
+    if (!friendship.getTimeAttackAlarm()) {
+      throw new BaseExceptionV2(TIME_ATTACK_ALARM_OFF);
+    }
+    List<Product> friendWishList = timeAttackService.getFriendWishList(friendIdx);
+    // Get random product from friend's wish list
+    Product randomProduct = productService.getRandomProduct(friendWishList, excludeProductId);
+    ProductSummaryDTO productSummaryDTO = new ProductSummaryDTO(
+        randomProduct,
+        productService.getLikeStatus(randomProduct.getIdx(), userIdx)
+    );
+    return ResponseEntity.ok(productSummaryDTO);
+  }
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -1,7 +1,14 @@
 package clov3r.api.timeattack.controller;
 
+import static clov3r.api.common.error.errorcode.CustomErrorCode.*;
+
 import clov3r.api.auth.security.Auth;
+import clov3r.api.common.error.errorcode.CustomErrorCode;
+import clov3r.api.common.error.exception.BaseExceptionV2;
+import clov3r.api.friend.repository.FriendshipRepository;
+import clov3r.api.friend.service.FriendService;
 import clov3r.api.timeattack.service.TimeAttackService;
+import clov3r.domain.domains.entity.Friendship;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,13 +19,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TimeAttackControllerImpl implements TimeAttackController {
   private final TimeAttackService timeAttackService;
+  private final FriendService friendService;
+  private final FriendshipRepository friendshipRepository;
 
   @Override
   public ResponseEntity<String> toggleTimeAttackAlarm(
       @PathVariable Long friendIdx,
       @Parameter(hidden = true) @Auth Long userIdx
   ) {
-    Boolean timeAttackAlarm = timeAttackService.toggleTimeAttackAlarm(friendIdx, userIdx);
+    Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx);
+    if (friendship == null) {
+      throw new BaseExceptionV2(NOT_FOUND_FRIENDSHIP);
+    }
+    Boolean timeAttackAlarm = timeAttackService.toggleTimeAttackAlarm(friendship);
     return ResponseEntity.ok(userIdx + "의 친구 " + friendIdx + "의 타임어택 알람 여부 :" + timeAttackAlarm);
   }
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -65,7 +65,7 @@ public class TimeAttackControllerImpl implements TimeAttackController {
   public ResponseEntity<ProductSummaryDTO> getFriendWishListRandomProduct(
       @PathVariable Long friendIdx,
       @Parameter(hidden = true) @Auth Long userIdx,
-      @Parameter(description = "제외할 제품 ID") Long excludeProductId
+      @Parameter(description = "제외할 제품 IDX") Long excludeProductIdx
   ) {
     Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx);
     if (friendship == null) {
@@ -76,7 +76,7 @@ public class TimeAttackControllerImpl implements TimeAttackController {
     }
     List<Product> friendWishList = timeAttackService.getFriendWishList(friendIdx);
     // Get random product from friend's wish list
-    Product randomProduct = productService.getRandomProduct(friendWishList, excludeProductId);
+    Product randomProduct = productService.getRandomProduct(friendWishList, excludeProductIdx);
     ProductSummaryDTO productSummaryDTO = new ProductSummaryDTO(
         randomProduct,
         productService.getLikeStatus(randomProduct.getIdx(), userIdx)

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -1,0 +1,24 @@
+package clov3r.api.timeattack.controller;
+
+import clov3r.api.auth.security.Auth;
+import clov3r.api.timeattack.service.TimeAttackService;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TimeAttackControllerImpl implements TimeAttackController {
+  private final TimeAttackService timeAttackService;
+
+  @Override
+  public ResponseEntity<String> toggleTimeAttackAlarm(
+      @PathVariable Long friendIdx,
+      @Parameter(hidden = true) @Auth Long userIdx
+  ) {
+    Boolean timeAttackAlarm = timeAttackService.toggleTimeAttackAlarm(friendIdx, userIdx);
+    return ResponseEntity.ok(userIdx + "의 친구 " + friendIdx + "의 타임어택 알람 여부 :" + timeAttackAlarm);
+  }
+}

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -5,6 +5,7 @@ import static clov3r.api.common.error.errorcode.CustomErrorCode.*;
 import clov3r.api.auth.security.Auth;
 import clov3r.api.common.error.errorcode.CustomErrorCode;
 import clov3r.api.common.error.exception.BaseExceptionV2;
+import clov3r.api.friend.domain.dto.FriendDTO;
 import clov3r.api.friend.repository.FriendshipRepository;
 import clov3r.api.friend.service.FriendService;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
@@ -81,5 +82,13 @@ public class TimeAttackControllerImpl implements TimeAttackController {
         productService.getLikeStatus(randomProduct.getIdx(), userIdx)
     );
     return ResponseEntity.ok(productSummaryDTO);
+  }
+
+  @Override
+  public ResponseEntity<List<FriendDTO>> getBirthdayFriends(
+      @Parameter(hidden = true) @Auth Long userIdx
+  ) {
+    List<FriendDTO> birthdayFriends = timeAttackService.getBirthdayFriends(userIdx);
+    return ResponseEntity.ok(birthdayFriends);
   }
 }

--- a/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
+++ b/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
@@ -1,5 +1,6 @@
 package clov3r.api.timeattack.service;
 
+import clov3r.api.friend.domain.dto.FriendDTO;
 import clov3r.api.friend.repository.FriendshipRepository;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
 import clov3r.api.product.domain.status.LikeStatus;
@@ -7,6 +8,9 @@ import clov3r.api.product.repository.ProductLikeRepository;
 import clov3r.api.product.service.ProductService;
 import clov3r.domain.domains.entity.Friendship;
 import clov3r.domain.domains.entity.Product;
+import clov3r.domain.domains.entity.User;
+import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TimeAttackService {
   private final ProductLikeRepository productLikeRepository;
+  private final FriendshipRepository friendshipRepository;
 
   public Boolean toggleTimeAttackAlarm(Friendship friendship) {
     friendship.changeTimeAttackAlarm();
@@ -26,4 +31,26 @@ public class TimeAttackService {
   public List<Product> getFriendWishList(Long friendIdx) {
     return productLikeRepository.findLikeProductList(friendIdx, LikeStatus.LIKE);
   }
+
+  public List<FriendDTO> getBirthdayFriends(Long userIdx) {
+    int days = 7;
+    List<User> birthdayFriends = friendshipRepository.findBirthdayFriends(userIdx, days);
+    // sort by closest birthday
+    birthdayFriends.sort((a, b) -> {
+      int aDiff = diffDays(a.getBirthDate(), LocalDate.now());
+      int bDiff = diffDays(b.getBirthDate(), LocalDate.now());
+      return Integer.compare(Math.abs(aDiff), Math.abs(bDiff));
+    });
+    return birthdayFriends.stream()
+        .map(FriendDTO::new)
+        .toList();
+  }
+
+  public int diffDays(LocalDate target, LocalDate today) {
+    if (target.getMonthValue() < today.getMonthValue()) {
+      return target.getDayOfYear() + (today.lengthOfYear() - today.getDayOfYear());
+    }
+    return target.getDayOfMonth() - today.getDayOfMonth();
+  }
+
 }

--- a/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
+++ b/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
@@ -12,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TimeAttackService {
   private final FriendshipRepository friendshipRepository;
 
-  public Boolean toggleTimeAttackAlarm(Long friendIdx, Long userIdx) {
-    Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx);
+  public Boolean toggleTimeAttackAlarm(Friendship friendship) {
     friendship.changeTimeAttackAlarm();
     return friendship.getTimeAttackAlarm();
   }

--- a/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
+++ b/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
@@ -1,0 +1,20 @@
+package clov3r.api.timeattack.service;
+
+import clov3r.api.friend.repository.FriendshipRepository;
+import clov3r.domain.domains.entity.Friendship;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TimeAttackService {
+  private final FriendshipRepository friendshipRepository;
+
+  public Boolean toggleTimeAttackAlarm(Long friendIdx, Long userIdx) {
+    Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx);
+    friendship.changeTimeAttackAlarm();
+    return friendship.getTimeAttackAlarm();
+  }
+}

--- a/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
+++ b/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
@@ -1,7 +1,13 @@
 package clov3r.api.timeattack.service;
 
 import clov3r.api.friend.repository.FriendshipRepository;
+import clov3r.api.product.domain.dto.ProductSummaryDTO;
+import clov3r.api.product.domain.status.LikeStatus;
+import clov3r.api.product.repository.ProductLikeRepository;
+import clov3r.api.product.service.ProductService;
 import clov3r.domain.domains.entity.Friendship;
+import clov3r.domain.domains.entity.Product;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,10 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class TimeAttackService {
-  private final FriendshipRepository friendshipRepository;
+  private final ProductLikeRepository productLikeRepository;
 
   public Boolean toggleTimeAttackAlarm(Friendship friendship) {
     friendship.changeTimeAttackAlarm();
     return friendship.getTimeAttackAlarm();
+  }
+
+  public List<Product> getFriendWishList(Long friendIdx) {
+    return productLikeRepository.findLikeProductList(friendIdx, LikeStatus.LIKE);
   }
 }

--- a/api/src/main/resources/db/migration/V2__add_time_attack_alarm_to_friendship.sql
+++ b/api/src/main/resources/db/migration/V2__add_time_attack_alarm_to_friendship.sql
@@ -1,0 +1,1 @@
+ALTER TABLE friendship ADD COLUMN time_attack_alarm BOOLEAN NOT NULL DEFAULT FALSE;

--- a/domain/src/main/java/clov3r/domain/domains/entity/Friendship.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/Friendship.java
@@ -1,6 +1,7 @@
 package clov3r.domain.domains.entity;
 
 import clov3r.domain.domains.status.Status;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -34,6 +35,9 @@ public class Friendship extends BaseEntity {
   @JoinColumn(name = "friend_idx")
   private User friend;
 
+  @Column(name = "time_attack_alarm")
+  private Boolean timeAttackAlarm;
+
   @Setter
   @Enumerated(EnumType.STRING)
   private Status status;
@@ -48,5 +52,9 @@ public class Friendship extends BaseEntity {
   public void deleteFriendship() {
     this.status = Status.DELETED;
     this.deleteBaseEntity();
+  }
+
+  public void changeTimeAttackAlarm() {
+    this.timeAttackAlarm = !this.timeAttackAlarm;
   }
 }


### PR DESCRIPTION
# [ONE-892] 타임어택 수신 토글
## 🔑 Key Change 
- 친구 관계인지 확인
- 해당 친구의 타임어택 알림을 받을 지 여부
- 토글 형식 : api 요청시마다 boolean 값 변경 (true <-> false)

# [ONE-873] 위시리스트 제품 조회(일반, 랜덤)
## 🔑 Key Change 
- 친구 관계인지 확인
- 해당 친구의 타임어택 수신동의했는지 여부 확인
- 친구가 좋아요한 상품 목록 리스트 조회(일반)
- 랜덤 조회는 api 요청할 때마다 위시리스트의 제품 중 1개가 랜덤으로 표시됨
(excludeProductIdx : 제외할 상품 idx 쿼리 파람으로 받음 -> 이전에 조회된 상품 idx를 넣어서 적어도 연속으로 같은 제품이 나오지 않도록)

# [ONE-895] 7일 이내 생일인 친구 목록 조회
## 🔑 Key Change 
- 오늘을 기준으로 7일 이내에 생일인 친구 목록 조회 (당일이 생일인 친구 ~ 7일 이후 생일인 친구까지)
- 오늘을 기준으로 생일이 가까운 친구순으로 정렬

## 🖼️ Screenshots (if necessary)
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/b27b608c-15d7-4da2-b57b-2015e717744f">
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/0fc5152a-a3ec-476e-8881-f3413805f916">



## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 

- 위시리스트 랜덤 조회 api 
: 연속으로 중복 상품이 안나오더라도 2번안에 같은 제품이 나올 경우가 충분함, 
중복으로 나오지 않으려면 이전에 나왔던 상품 목록에 대한 정보를 매번 누적해서 받아야 하는데 이게 맞나..?
차라리 전체 위시리스트 조회 api에서 프론트 상에서 하나씩 랜덤으로 보여주는 건 어떨지? 그래도 프론트 상에서도 복잡하긴 할 듯

- 생일 친구 조회 api
: 7로 하드코딩 되이있는데, 며칠 이내인지 day도 input으로 받을까?

- 전체 다 계정 정보 필수

[ONE-892]: https://clov3r.atlassian.net/browse/ONE-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONE-873]: https://clov3r.atlassian.net/browse/ONE-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONE-895]: https://clov3r.atlassian.net/browse/ONE-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ