### PR TITLE
[feature] add time attack alarm in friend dto for getting friends list

### DIFF
--- a/api/src/main/java/clov3r/api/auth/service/UserService.java
+++ b/api/src/main/java/clov3r/api/auth/service/UserService.java
@@ -9,6 +9,7 @@ import clov3r.api.common.error.exception.BaseExceptionV2;
 import clov3r.api.auth.repository.UserRepository;
 import clov3r.api.common.service.S3Service;
 import clov3r.api.friend.domain.dto.OtherUserDTO;
+import clov3r.api.friend.repository.FriendshipRepository;
 import clov3r.api.friend.service.FriendService;
 import clov3r.api.notification.service.NotificationService;
 import clov3r.domain.domains.entity.User;
@@ -25,6 +26,7 @@ public class UserService {
     private final S3Service s3Service;
     private final FriendService friendService;
     private final NotificationService notificationService;
+    private final FriendshipRepository friendshipRepository;
 
     public UserDTO getUser(Long userIdx) {
         User user = userRepository.findByUserIdx(userIdx);
@@ -83,7 +85,12 @@ public class UserService {
 
     public OtherUserDTO getOtherUser(Long userIdx, Long friendIdx) {
         User user = userRepository.findByUserIdx(friendIdx);
-        return new OtherUserDTO(user, friendService.isFriend(userIdx, friendIdx));
+        boolean isFriend = friendService.isFriend(userIdx, friendIdx);
+        OtherUserDTO otherUserDTO = new OtherUserDTO(user, isFriend);
+        if (isFriend) {
+            otherUserDTO.setTimeAttackAlarm(friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friendIdx).getTimeAttackAlarm());
+        }
+        return otherUserDTO;
     }
 
 }

--- a/api/src/main/java/clov3r/api/friend/domain/dto/FriendDTO.java
+++ b/api/src/main/java/clov3r/api/friend/domain/dto/FriendDTO.java
@@ -5,24 +5,27 @@ import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class FriendDTO {
 
-      private Long idx;
-      private String name;
-      private String nickName;
-      private String profileImg;
-      private LocalDate birthDate;
+  private Long idx;
+  private String name;
+  private String nickName;
+  private String profileImg;
+  private LocalDate birthDate;
+  @Setter
+  private boolean timeAttackAlarm;
 
-      public FriendDTO(User user) {
-        this.idx = user.getIdx();
-        this.name = user.getName();
-        this.nickName = user.getNickname();
-        this.profileImg = user.getProfileImg();
-        this.birthDate = user.getBirthDate();
-      }
+  public FriendDTO(User user) {
+    this.idx = user.getIdx();
+    this.name = user.getName();
+    this.nickName = user.getNickname();
+    this.profileImg = user.getProfileImg();
+    this.birthDate = user.getBirthDate();
+  }
 
 }

--- a/api/src/main/java/clov3r/api/friend/domain/dto/OtherUserDTO.java
+++ b/api/src/main/java/clov3r/api/friend/domain/dto/OtherUserDTO.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,6 +15,8 @@ public class OtherUserDTO {
   private String profileImg;
   private LocalDate birthDate;
   private Boolean isFriend;
+  @Setter
+  private boolean timeAttackAlarm;
 
   public OtherUserDTO(User user, Boolean isFriend) {
     this.idx = user.getIdx();

--- a/api/src/main/java/clov3r/api/friend/service/FriendService.java
+++ b/api/src/main/java/clov3r/api/friend/service/FriendService.java
@@ -107,7 +107,11 @@ public class FriendService {
   public List<FriendDTO> getFriends(Long userIdx) {
     List<Friendship> friendshipsList = friendshipRepository.findByUserIdx(userIdx);
     return friendshipsList.stream()
-        .map(friendship -> new FriendDTO(friendship.getFriend()))
+        .map(friendship -> {
+          FriendDTO friendDTO = new FriendDTO(friendship.getFriend());
+          friendDTO.setTimeAttackAlarm(friendship.getTimeAttackAlarm());
+          return friendDTO;
+          })
         .toList();
   }
 }

--- a/api/src/main/java/clov3r/api/product/repository/ProductLikeRepository.java
+++ b/api/src/main/java/clov3r/api/product/repository/ProductLikeRepository.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
 
-  @Query("SELECT pl FROM ProductLike pl WHERE pl.productIdx = :productIdx AND pl.userIdx = :userIdx")
+  @Query("SELECT pl FROM ProductLike pl WHERE pl.product.idx = :productIdx AND pl.user.idx = :userIdx")
   ProductLike findProductLike(Long productIdx, Long userIdx);
 
-  @Query("SELECT COUNT(pl) FROM ProductLike pl WHERE pl.productIdx = :productIdx AND pl.likeStatus = :likeStatus")
+  @Query("SELECT COUNT(pl) FROM ProductLike pl WHERE pl.product.idx = :productIdx AND pl.likeStatus = :likeStatus")
   int countByProductIdxAndLikeStatus(Long productIdx, LikeStatus likeStatus);
 
-  @Query("SELECT p FROM Product p JOIN ProductLike pl ON p.idx = pl.productIdx WHERE pl.userIdx = :userIdx AND pl.likeStatus = :likeStatus")
+  @Query("SELECT p FROM Product p JOIN ProductLike pl ON p.idx = pl.product.idx WHERE pl.user.idx = :userIdx AND pl.likeStatus = :likeStatus")
   List<Product> findLikeProductList(Long userIdx, LikeStatus likeStatus);
 
 }

--- a/api/src/main/java/clov3r/api/product/repository/ProductRepository.java
+++ b/api/src/main/java/clov3r/api/product/repository/ProductRepository.java
@@ -1,11 +1,13 @@
 package clov3r.api.product.repository;
 
 import static clov3r.domain.domains.entity.QProduct.product;
+import static clov3r.domain.domains.entity.QProductLike.productLike;
 
 import clov3r.api.product.domain.collection.MatchedProduct;
 import clov3r.api.product.domain.collection.ProductFilter;
 import clov3r.api.product.domain.collection.ProductSearch;
 import clov3r.api.product.domain.collection.QuestionCategory;
+import clov3r.api.product.domain.status.LikeStatus;
 import clov3r.api.product.domain.status.ProductStatus;
 import clov3r.domain.domains.entity.Product;
 import clov3r.domain.domains.type.Gender;
@@ -307,5 +309,14 @@ public class ProductRepository {
                 .where(product.idx.eq(productIdx))
                 .execute();
     }
+
+    public boolean existsProductLike(Long userIdx) {
+        return queryFactory.select(productLike)
+            .from(productLike)
+            .where(productLike.user.idx.eq(userIdx)
+                .and(productLike.likeStatus.eq(LikeStatus.LIKE)))
+            .fetchFirst() != null;
+    }
+
 }
 

--- a/api/src/main/java/clov3r/api/product/service/ProductService.java
+++ b/api/src/main/java/clov3r/api/product/service/ProductService.java
@@ -1,5 +1,9 @@
 package clov3r.api.product.service;
 
+import static clov3r.domain.domains.entity.QProduct.product;
+import static net.sf.jsqlparser.util.validation.metadata.NamedObject.user;
+
+import clov3r.api.auth.repository.UserRepository;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
 import clov3r.api.product.domain.collection.ProductFilter;
 import clov3r.api.product.domain.collection.ProductSearch;
@@ -23,6 +27,7 @@ public class ProductService {
   private final ProductRepository productRepository;
   private final KeywordRepository keywordRepository;
   private final ProductLikeRepository productLikeRepository;
+  private final UserRepository userRepository;
 
 
   public List<ProductSummaryDTO> filterProducts(ProductFilter productFilter, Long userIdx) {
@@ -102,8 +107,8 @@ public class ProductService {
       }
     } else {
       ProductLike newProductLike = ProductLike.builder()
-          .productIdx(productIdx)
-          .userIdx(userIdx)
+          .product(productRepository.findById(productIdx))
+          .user(userRepository.findByUserIdx(userIdx))
           .likeStatus(LikeStatus.LIKE)
           .build();
       newProductLike.createBaseEntity();

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackController.java
@@ -3,6 +3,7 @@ package clov3r.api.timeattack.controller;
 import clov3r.api.auth.security.Auth;
 import clov3r.api.friend.domain.dto.FriendDTO;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
+import clov3r.api.timeattack.dto.BirthdayFriendDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,7 +42,7 @@ public interface TimeAttackController {
 
   @Operation(summary = "7일 이내 생일인 친구 조회", description = "7일 이내 생일인 친구를 조회합니다.")
   @GetMapping("/api/v2/friends/birthday")
-  ResponseEntity<List<FriendDTO>> getBirthdayFriends(
+  ResponseEntity<List<BirthdayFriendDTO>> getBirthdayFriends(
       @Parameter(hidden = true) @Auth Long userIdx
   );
 }

--- a/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
+++ b/api/src/main/java/clov3r/api/timeattack/controller/TimeAttackControllerImpl.java
@@ -10,6 +10,7 @@ import clov3r.api.friend.repository.FriendshipRepository;
 import clov3r.api.friend.service.FriendService;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
 import clov3r.api.product.service.ProductService;
+import clov3r.api.timeattack.dto.BirthdayFriendDTO;
 import clov3r.api.timeattack.service.TimeAttackService;
 import clov3r.domain.domains.entity.Friendship;
 import clov3r.domain.domains.entity.Product;
@@ -85,10 +86,10 @@ public class TimeAttackControllerImpl implements TimeAttackController {
   }
 
   @Override
-  public ResponseEntity<List<FriendDTO>> getBirthdayFriends(
+  public ResponseEntity<List<BirthdayFriendDTO>> getBirthdayFriends(
       @Parameter(hidden = true) @Auth Long userIdx
   ) {
-    List<FriendDTO> birthdayFriends = timeAttackService.getBirthdayFriends(userIdx);
+    List<BirthdayFriendDTO> birthdayFriends = timeAttackService.getBirthdayFriends(userIdx);
     return ResponseEntity.ok(birthdayFriends);
   }
 }

--- a/api/src/main/java/clov3r/api/timeattack/dto/BirthdayFriendDTO.java
+++ b/api/src/main/java/clov3r/api/timeattack/dto/BirthdayFriendDTO.java
@@ -1,0 +1,33 @@
+package clov3r.api.timeattack.dto;
+
+import clov3r.domain.domains.entity.User;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BirthdayFriendDTO {
+
+  private Long idx;
+  private String name;
+  private String nickName;
+  private String profileImg;
+  private LocalDate birthDate;
+  @Setter
+  private boolean timeAttackAlarm;
+  @Setter
+  private boolean haveWishList;
+
+  public BirthdayFriendDTO(User user) {
+    this.idx = user.getIdx();
+    this.name = user.getName();
+    this.nickName = user.getNickname();
+    this.profileImg = user.getProfileImg();
+    this.birthDate = user.getBirthDate();
+  }
+
+}

--- a/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
+++ b/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
@@ -42,7 +42,12 @@ public class TimeAttackService {
       return Integer.compare(Math.abs(aDiff), Math.abs(bDiff));
     });
     return birthdayFriends.stream()
-        .map(FriendDTO::new)
+        .map(friend -> {
+          Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friend.getIdx());
+          FriendDTO friendDTO = new FriendDTO(friend);
+          friendDTO.setTimeAttackAlarm(friendship.getTimeAttackAlarm());
+          return friendDTO;
+        })
         .toList();
   }
 

--- a/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
+++ b/api/src/main/java/clov3r/api/timeattack/service/TimeAttackService.java
@@ -5,7 +5,9 @@ import clov3r.api.friend.repository.FriendshipRepository;
 import clov3r.api.product.domain.dto.ProductSummaryDTO;
 import clov3r.api.product.domain.status.LikeStatus;
 import clov3r.api.product.repository.ProductLikeRepository;
+import clov3r.api.product.repository.ProductRepository;
 import clov3r.api.product.service.ProductService;
+import clov3r.api.timeattack.dto.BirthdayFriendDTO;
 import clov3r.domain.domains.entity.Friendship;
 import clov3r.domain.domains.entity.Product;
 import clov3r.domain.domains.entity.User;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TimeAttackService {
   private final ProductLikeRepository productLikeRepository;
   private final FriendshipRepository friendshipRepository;
+  private final ProductRepository productRepository;
 
   public Boolean toggleTimeAttackAlarm(Friendship friendship) {
     friendship.changeTimeAttackAlarm();
@@ -32,7 +35,7 @@ public class TimeAttackService {
     return productLikeRepository.findLikeProductList(friendIdx, LikeStatus.LIKE);
   }
 
-  public List<FriendDTO> getBirthdayFriends(Long userIdx) {
+  public List<BirthdayFriendDTO> getBirthdayFriends(Long userIdx) {
     int days = 7;
     List<User> birthdayFriends = friendshipRepository.findBirthdayFriends(userIdx, days);
     // sort by closest birthday
@@ -44,9 +47,11 @@ public class TimeAttackService {
     return birthdayFriends.stream()
         .map(friend -> {
           Friendship friendship = friendshipRepository.findByUserIdxAndFriendIdx(userIdx, friend.getIdx());
-          FriendDTO friendDTO = new FriendDTO(friend);
-          friendDTO.setTimeAttackAlarm(friendship.getTimeAttackAlarm());
-          return friendDTO;
+          boolean haveWishList = productRepository.existsProductLike(friend.getIdx());
+          BirthdayFriendDTO birthdayFriendDTO = new BirthdayFriendDTO(friend);
+          birthdayFriendDTO.setTimeAttackAlarm(friendship.getTimeAttackAlarm());
+          birthdayFriendDTO.setHaveWishList(haveWishList);
+          return birthdayFriendDTO;
         })
         .toList();
   }

--- a/domain/src/main/java/clov3r/domain/domains/entity/ProductLike.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/ProductLike.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,10 +27,14 @@ import lombok.Setter;
 public class ProductLike extends BaseEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
-  @Column(name = "user_idx")
-  private Long userIdx;
-  @Column(name = "product_idx")
-  private Long productIdx;
+
+  @ManyToOne
+  @JoinColumn(name = "user_idx")
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "product_idx")
+  private Product product;
 
   @Setter
   @Column(name = "like_status")


### PR DESCRIPTION
# DTO에 타임 어택 알림 여부 추가
## 🔑 Key Change 
- boolean timeAttackAlarm
1. 친구 목록 조회
2. 7일 이내 생일인 친구 목록 조회
3. 다른 유저 프로필 조회
* 아직 친구가 아닌 경우 디폴트로 false로 조회됨 (ex. 친구 요청 목록에서는 아직 친구가 되기 전이므로 false로 조회)

# 위시리스트 존재 여부 확인
## 🔑 Key Change 
- 7일 이내 생일자 조회시 해당 생일자가 위시리스틑 가지고 있는지 확인하여 그 여부를 boolean으로 응답


## 🖼️ Screenshots (if necessary)
1. 친구 목록 조회
<img width="276" alt="image" src="https://github.com/user-attachments/assets/bd999dff-1a52-4eed-9046-7fdb9286f585">

2. 7일 이내 생일 친구 목록 조회
<img width="273" alt="image" src="https://github.com/user-attachments/assets/90c4ca64-a334-4ebc-8bce-9e496e4741f0">


3. 다른 유저 프로필 조회
<img width="280" alt="image" src="https://github.com/user-attachments/assets/16e59448-5ca8-4144-8ca0-c8549821dbf2">


## 🙏 To Reviewers
🧑‍🤝‍🧑 @R3D1NM 
- remark 1
