### PR TITLE
[Fix] 상품 좋아요 카운드 업데이트 되지 않는 이슈

### DIFF
--- a/domain/src/main/java/clov3r/domain/domains/entity/Comment.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/Comment.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,7 +30,7 @@ public class Comment extends BaseEntity {
   @Column(name = "giftbox_product_idx")
   private Long giftboxProductIdx;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "writer_idx")
   private User writer;
   private String content;

--- a/domain/src/main/java/clov3r/domain/domains/entity/FriendReq.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/FriendReq.java
@@ -4,6 +4,7 @@ import clov3r.domain.domains.status.FriendReqStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,11 +28,11 @@ public class FriendReq extends BaseEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "from_idx")
   private User from;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "to_idx")
   private User to;
 

--- a/domain/src/main/java/clov3r/domain/domains/entity/Friendship.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/Friendship.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,11 +28,11 @@ public class Friendship extends BaseEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_idx")
   private User user;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "friend_idx")
   private User friend;
 

--- a/domain/src/main/java/clov3r/domain/domains/entity/Inquiry.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/Inquiry.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +26,11 @@ public class Inquiry extends BaseEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "giftbox_idx")
   private Giftbox giftbox;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_idx")
   private User user;
 

--- a/domain/src/main/java/clov3r/domain/domains/entity/Notification.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/Notification.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,15 +31,15 @@ public class Notification extends BaseEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "receiver_idx")
   private User receiver;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "sender_idx")
   private User sender;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "device_idx")
   private Device device;
 

--- a/domain/src/main/java/clov3r/domain/domains/entity/ProductLike.java
+++ b/domain/src/main/java/clov3r/domain/domains/entity/ProductLike.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,11 +29,11 @@ public class ProductLike extends BaseEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long idx;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_idx")
   private User user;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_idx")
   private Product product;
 


### PR DESCRIPTION
# [Fix] 상품 좋아요 카운드 업데이트 되지 않는 이슈
## 🔑 Key Change 
🚫 문제 상황
- 상품 좋아요 클릭시 DB 상에는 LikeStatus = "LIKE"로 변경, LikeCount +1 되지만,
응답값 반환을 위해 조회했을 때 LikeCount는 업데이트되지 않고 이전 값이 반영됨(LikeStatus는 제대로 가져옴)
- 반대로 좋아요 취소시에는 LikeStatus = "NONE" 변경, LikeCount + 1된 상태가 조회됨
🔍 원인
- ProductLike 엔티티(유저-상품좋아요 정보)를 조회할 때, 연관관계인 Product 엔티티도 함께 가져와서 영속성 컨텍스트에 캐싱됨
- 이후 DB상의 Product 에 LikeCount를 업데이트 하고, 응답값 반환을 위해 조회를 할 때에 DB에 쿼리 날리지 않고, 캐싱된 product를 가져오기 때문에 업데이트 되기 전 좋아요 개수를 반환하기 때문
✅ 해결
- ProductLike 엔티티와 N:1 연관관계인 Product에 지연로딩을 걸어줌
`@ManyToOne(fetch = FetchType.LAZY)`
- 업데이트 완료후(transactional 끝난 뒤) product 조회할 때 DB에 쿼리를 날려 가져옴

![image](https://github.com/user-attachments/assets/75747fee-8c0a-4269-9551-574abae484ed)


## 🖼️ Screenshots (if necessary)
해결 전
![image](https://github.com/user-attachments/assets/68666810-fd12-4f56-9aba-441b5575ffd0)
![image](https://github.com/user-attachments/assets/4fcdc57b-0c18-4375-b430-6ee34922e7bc)

해결 후
![image](https://github.com/user-attachments/assets/32402d03-be91-4869-86cd-d50902818f1c)
![image](https://github.com/user-attachments/assets/f9340815-005f-43cc-993d-db7fd47aee5f)


## 🙏 To Reviewers
🧑‍🤝‍🧑 @Teammate_name
- remark 1
